### PR TITLE
Add UI card editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Energy Sankey is a collection of dashboard cards for homeassistant, dynamically 
 
 ![alt text](image.png)
 
-The cards are ideal if you want to track your energy consumption and identify where your energy is going.
+The cards are ideal if you want to track your electricity consumption and identify where your energy is going.
 
 The aim is for as easy setup as possible. No configuring groups of child entities, complicated choices or hunting for info to populate a yaml configuration. In most cases, the default configuration should just work.
 
@@ -34,7 +34,7 @@ The diagram dynamically scales to fit the size of the window it is in (mostly).
  - Reload when prompted
  - Select a dashboard and enter editing mode
  - Type 'Sankey' in the search box
- - Select 'Custom: Sankey Energy Flow Card' or 'Custom: Sakney Power Flow Card'
+ - Select 'Custom: Sankey Energy Flow Card' or 'Custom: Sankey Power Flow Card'
    - The energy card does not require configuration
    - The power card auto configures. If there are any problems with autoconfiguration, edit the displayed yaml to select the correct power entities for grid input / generation / consumers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,21 @@
       "name": "energy-sankey-cards",
       "version": "0.0.1",
       "dependencies": {
-        "@davethompson/elec-sankey": "^1.0.0",
         "@material/mwc-icon-button": "^0.27.0",
+        "@material/mwc-list": "^0.27.0",
+        "@material/mwc-textfield": "^0.27.0",
         "@mdi/js": "^7.4.47",
+        "@vaadin/combo-box": "24.5.3",
+        "@vaadin/vaadin-themable-mixin": "24.5.3",
         "color-name": "^2.0.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "home-assistant-js-websocket": "^9.4.0",
-        "lit": "^2.8.0",
-        "memoize-one": "^6.0.0"
+        "memoize-one": "^6.0.0",
+        "sortablejs": "^1.15.6"
       },
       "devDependencies": {
+        "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-typescript": "^11.1.6",
@@ -28,16 +32,6 @@
         "rollup-plugin-serve": "^2.0.3",
         "tslib": "^2.8.0",
         "typescript": "^5.5.3"
-      }
-    },
-    "node_modules/@davethompson/elec-sankey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@davethompson/elec-sankey/-/elec-sankey-1.0.0.tgz",
-      "integrity": "sha512-InTaMKgkia9xDdSKQ4AOrI1NnLuxeaXGbB7IjuEZkcH7apq5eG4XGrZmpIQI00D/Fq9dgyvKAs64bL7D9uvZEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdi/js": "^7.4.47",
-        "lit": "^2.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -149,9 +143,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.1.tgz",
-      "integrity": "sha512-HFZ4Mp26nbWk9d/BpvP0YNL6W4UoZF0VFcTw/aPPA8RpOxeFQgK+ClABGgAUXs9Y/RGX/l1vOmrqz1MQt9MNuw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -219,15 +213,6 @@
       "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@material/animation": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
@@ -246,6 +231,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/density": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-Eh/vZ3vVyqtpylg5Ci33qlgtToS4H1/ppd450Ib3tcdISIoodgijYY0w4XsRvrnZgbI/h/1STFdLxdzS0UNuFw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/dom": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
@@ -256,12 +250,84 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/elevation": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/feature-targeting": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
       "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
       "license": "MIT",
       "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-gHZUTTVKnP+Zjz4l9IT/G89NPmypn5FlTGLWKKqXbuQphr37rsKFR3Y80SJxULRyMDnAdKSxuZwiXLFKQz9KlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-exPX5VrjQimipBwgcFDGRiEE783sOBgpkFui59A6i6iGvS2UrLHlYY2E65fyyyQnD1f/rv4Po1OOnCesE1kulg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-k8f8uuDwnSqZZ98CzbYtQVtxlp1ryUup9nd2uobo3kiqQNlQfXdGkVjuCXcla0OPiKFizNn7dS6Kl/j6L09XUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-mkMpltSKAYLBtFnTTCk/mQIDzwxF/VLh1gh59ehOtmRXt7FvTz83RoAa4tqe53hpVrbX4HoLDBu+vILhq/wkjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
         "tslib": "^2.1.0"
       }
     },
@@ -278,6 +344,31 @@
         "tslib": "^2.0.1"
       }
     },
+    "node_modules/@material/mwc-checkbox": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-checkbox/-/mwc-checkbox-0.27.0.tgz",
+      "integrity": "sha512-EY0iYZLwo8qaqMwR5da4fdn0xI0BZNAvKTcwoubYWpDDHlGxDcqwvjp/40ChGo3Q/zv8/4/A0Qp7cwapI82EkA==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-floating-label": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-floating-label/-/mwc-floating-label-0.27.0.tgz",
+      "integrity": "sha512-uLleloTxQ6dDShcZzqgqfC8otQY8DtGMO9HFQbAEncoFAWpAehcEonsuT/IUhMORN+c5un0P5WXwcZsInJb7og==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
     "node_modules/@material/mwc-icon-button": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.27.0.tgz",
@@ -286,6 +377,63 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-line-ripple": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-line-ripple/-/mwc-line-ripple-0.27.0.tgz",
+      "integrity": "sha512-n9Xpt5g3RJEl9rvk14OP6dUNJUtsJA46beTQiep7ppO7IPVFLC1v/5sPpUzfNPUBsclSPxdBuNlCxsgcIYueUw==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-list": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-list/-/mwc-list-0.27.0.tgz",
+      "integrity": "sha512-oAhNQsBuAOgF3ENOIY8PeWjXsl35HoYaUkl0ixBQk8jJP2HIEf+MdbS5688y/UXxFbSjr0m//LfwR5gauEashg==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/base": "=14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "@material/list": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-checkbox": "^0.27.0",
+        "@material/mwc-radio": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-notched-outline": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-notched-outline/-/mwc-notched-outline-0.27.0.tgz",
+      "integrity": "sha512-IlqfQVaEd1RAHqhOG0Xk5JhTDgBe/P9og0pnACglK6bPE0vUhYKwibJiHcr4ACTPtGWHO9o92aktR+7AIEAKtQ==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/notched-outline": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-radio": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-radio/-/mwc-radio-0.27.0.tgz",
+      "integrity": "sha512-+rSO9a373BgyMgQOM0Z8vVkuieobBylPJ8qpltytM+yGPj8+n+MtwRZyg+ry3WwEjYYDMP6GxZPHwLgWs6lMpQ==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "@material/radio": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
       }
@@ -302,6 +450,57 @@
         "@material/ripple": "=14.0.0-canary.53b3cad2f.0",
         "lit": "^2.0.0",
         "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/mwc-textfield": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-textfield/-/mwc-textfield-0.27.0.tgz",
+      "integrity": "sha512-4/OEeEVAWWQ1DzpjeMLYLsa9HMlifOPjAvi0681Yj1g/RYJs5ONZS80HZ8HOT+efAOlZDugshgM4gdNS3I0XFQ==",
+      "deprecated": "MWC beta is longer supported. Please upgrade to @material/web",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/floating-label": "=14.0.0-canary.53b3cad2f.0",
+        "@material/line-ripple": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-floating-label": "^0.27.0",
+        "@material/mwc-line-ripple": "^0.27.0",
+        "@material/mwc-notched-outline": "^0.27.0",
+        "@material/textfield": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-3ByiPOC/wWQmFKfgJS98kb5/6v92n7uIfJ6v6sryKJlJCJn39qfpGcCM5RpRIws1RET1s1zBJT2JDwYeu/hM5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/floating-label": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-V/AgWEOuHFoh9d4Gq1rqBZnKSGtMLQNh23Bwrv0c1FhPqFvUpwt9jR3SVwhJk5gvQQWGy9p3iiGc9QCJ+0+P8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@material/ripple": {
@@ -329,6 +528,41 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/shape": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-RyjInLCNe+nI/ulKea0ZLHphXQDiDqYazS25SRn18g8Hoa5qGNaY5oOBncDXUYn3jm5oI5kFc9oif//kulkbjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-Pla9Tr94Is18o97E/mqHKdkR24rPES9atGm3BlXrNzyr5tu6+h++RBbxy7V6IExcfl0MX+v9Gyqz7sPZzFtwMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/floating-label": "14.0.0-canary.53b3cad2f.0",
+        "@material/line-ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/notched-outline": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/tokens": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/theme": {
       "version": "14.0.0-canary.53b3cad2f.0",
       "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
@@ -339,11 +573,76 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/tokens": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-myHFB7vac8zErA3qgkqmV+kpE+i9JEwc/6Yf0MOumDSpylJGw28QikpNC6eAVBK2EmPQTaFn20mqUxyud8dGqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-d83e5vbqoLyL542yOTTp4TLVltddWiqbI/j1w/D9ipE30YKfe2EDN+CNJc32Zufh5IUfK41DsZdrN8fI9cL99A==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-9J0k2fq7uyHsRzRqJDJLGmg3YzRpfRPtFDVeUH/xBcYoqpZE7wYw5Mb7s/l8eP626EtR7HhXhSPjvRTLA6NIJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@mdi/js": {
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "license": "MIT"
+    },
+    "node_modules/@polymer/polymer": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.2.tgz",
+      "integrity": "sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
+      "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
@@ -692,6 +991,690 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@vaadin/a11y-base": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.5.6.tgz",
+      "integrity": "sha512-wi7sfDNh+QCLS+4D5WPPior2z0h0hPicOGuiawjuTJPilCj+715ZHE4VZBHcnK1KLrjagzBRk8xZkrcFVnu1Ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.5.6",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/a11y-base/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/a11y-base/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/a11y-base/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/a11y-base/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/combo-box": {
+      "version": "24.5.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/combo-box/-/combo-box-24.5.3.tgz",
+      "integrity": "sha512-q7TFvaBQmpFKUSIN0HFg7EdjVi9x8Qp1uOcO+RdhOnWoXSDGZTuAe+hlMxywMkY0UHYP5o+1nHRI1MhuI/yQmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.5.3",
+        "@vaadin/component-base": "~24.5.3",
+        "@vaadin/field-base": "~24.5.3",
+        "@vaadin/input-container": "~24.5.3",
+        "@vaadin/item": "~24.5.3",
+        "@vaadin/lit-renderer": "~24.5.3",
+        "@vaadin/overlay": "~24.5.3",
+        "@vaadin/vaadin-lumo-styles": "~24.5.3",
+        "@vaadin/vaadin-material-styles": "~24.5.3",
+        "@vaadin/vaadin-themable-mixin": "~24.5.3"
+      }
+    },
+    "node_modules/@vaadin/component-base": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.5.6.tgz",
+      "integrity": "sha512-WBixuCQfQXszRLPWpsgulf20870JEeQebGxjJ9vfyLAKYxguuhCJhlmudefSt8f7atRto+ghw67iPUlen+4tYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/component-base/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/component-base/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/component-base/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/component-base/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/field-base": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.5.6.tgz",
+      "integrity": "sha512-GT8V2Obo4H3lBxf45Wd8EreEyDgW8gC62WUz8vTp1PCQCydG8hz4cYsLebjBd9zdDGuktdPMDAz0Drwl/wtIGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.5.6",
+        "@vaadin/component-base": "~24.5.6",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/field-base/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/field-base/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/field-base/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/field-base/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/icon": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.5.6.tgz",
+      "integrity": "sha512-5SXmTdvZ94JZzbq0Gqv417N5Md6M+PViaOWMGsYOJiAePYXdOkQ88C05j4ItlL0CT7IAhp5jhIDqJU2sm7bHxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/vaadin-lumo-styles": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/icon/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/icon/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/icon/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/icon/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/icon/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/input-container": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.5.6.tgz",
+      "integrity": "sha512-UwrpBbWWp5GySOqwi5rYEUeWhmhaWYRaHgOzy/YvoE6YhYhJKTltkzK2y3nYouBzNocxbDG7RFkEMixxGxRdzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/vaadin-lumo-styles": "~24.5.6",
+        "@vaadin/vaadin-material-styles": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/input-container/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/input-container/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/item": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/item/-/item-24.5.6.tgz",
+      "integrity": "sha512-qZMPUYjXTvQE4jUI7rsGgmm4/zbK5MXGazUvWPDSVXy55Jl1v4O3rsKYsNyvE/DJ4xpRb6NUp5RGxXxqIRofrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.5.6",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/vaadin-lumo-styles": "~24.5.6",
+        "@vaadin/vaadin-material-styles": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6"
+      }
+    },
+    "node_modules/@vaadin/item/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/item/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/item/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/item/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/item/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.5.6.tgz",
+      "integrity": "sha512-yEu3SCMenh6pC64KHj4FHmw60jR90u5T4YdDqleaQZLbRCYkoeE7iLetw473r7yZFJ2rrcg7u1D8OaEL6oYbyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/overlay": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/overlay/-/overlay-24.5.6.tgz",
+      "integrity": "sha512-oWPUf2DXmaetZNCnVbaSagziDfM/DcktXYeId/HRv5lnsO+AHAaCkW5A78KkNes0nQ4/M6ASsKPWS0mEjD3nug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.5.6",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/vaadin-lumo-styles": "~24.5.6",
+        "@vaadin/vaadin-material-styles": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/overlay/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/overlay/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/overlay/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/overlay/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/overlay/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.7.tgz",
+      "integrity": "sha512-9FhVhr0ynSR3X2ao+vaIEttcNU5XfzCbxtmYOV8uIRnUCtNgbvMOIcyGBvntsX9I5kvIP2dV3cFAOG9SILJzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.5.6.tgz",
+      "integrity": "sha512-PmxNzRiZEpJWBJLLP6QzCubaqurJq5FEIixGF4HiTUrFPEsF4W6v7FROEpHU9qU8fQXk30ghKo191CHc8sVDMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/icon": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6"
+      }
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.5.6.tgz",
+      "integrity": "sha512-wghz8Evkwda82hqwht+VCjyScbjTBGTN1pY294LpQ2JKHc9KgBc9Z/nZ1fzgCTzm7uFXEPmitZPdOnrNIjAaqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.5.6",
+        "@vaadin/vaadin-themable-mixin": "~24.5.6"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles/node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
+      "integrity": "sha512-zPAhsZ6QfeUZJN8WXe9s6zIU5T/nYZ1ETDbHmGRtsDuGRaEADxGG8S49DVdUUWSoxg9poXIPQGVozur3q5TGmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.5.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.3.tgz",
+      "integrity": "sha512-I47ZoSrzezCt9uzi1l5lTQnpjyIZWvFIlrXeLZF1ZGmYjUqCZRu6C3DnQn6mBBdpcmDYSvFSWKL/+XkFwl35GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin/node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin/node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin/node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.3.tgz",
+      "integrity": "sha512-8r4TNknD7OJQADe3VygeofFR7UNAXZ2/jjBFP5dgI8+2uMfnuGYgbuHivasKr9WSQ64sPej6m8rDoM1uSllXjQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@webcomponents/shadycss": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
@@ -837,9 +1820,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -997,9 +1980,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1402,6 +2385,15 @@
         "lit-html": "^2.8.0"
       }
     },
+    "node_modules/lit-element/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "node_modules/lit-html": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
@@ -1409,6 +2401,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lit/node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -1726,6 +2727,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,16 +35,19 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -64,9 +67,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -74,13 +77,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.5",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -89,19 +92,22 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -123,9 +129,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.13.0.tgz",
-      "integrity": "sha512-IFLyoY4d72Z5y/6o/BazFBezupzI/taV8sGumxTAVw3lXG9A6md1Dc34T9s1FoD/an9pJH8RHbAxsaEbBed9lA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -133,9 +139,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -156,9 +162,9 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
-      "integrity": "sha512-2cbWIHbZVEweE853g8jymffCA+NCMiuqeECeBBLm8dg2oFdjuGJhgN4UAbI+6v0CKbbhvtXA4qV8YR5Ji86nmw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -166,17 +172,31 @@
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.5.tgz",
-      "integrity": "sha512-KSPA4umqSG4LHYRodq31VDwKAvaTF4xmVlzM8Aeh4PlU1JQ3IG0wiA8C25d3RQ9nJyM3mBHyI53K06VVL/oFFg==",
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.0",
+        "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
       },
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -194,9 +214,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -212,6 +232,15 @@
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
       "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "node_modules/@material/animation": {
       "version": "14.0.0-canary.53b3cad2f.0",
@@ -666,9 +695,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.0.tgz",
-      "integrity": "sha512-9eO5McEICxMzJpDW9OnMYSv4Sta3hmt7VtBFz5zR9273suNOydOyq/FrGeGy+KsTRFm8w0SLVhzig2ILFT63Ag==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -718,15 +747,15 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.2.tgz",
-      "integrity": "sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -741,9 +770,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
       "cpu": [
         "arm"
       ],
@@ -755,9 +784,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
       "cpu": [
         "arm64"
       ],
@@ -769,9 +798,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
       "cpu": [
         "arm64"
       ],
@@ -783,9 +812,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
       "cpu": [
         "x64"
       ],
@@ -796,10 +825,38 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
       "cpu": [
         "arm"
       ],
@@ -811,9 +868,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
       "cpu": [
         "arm"
       ],
@@ -825,9 +882,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
       "cpu": [
         "arm64"
       ],
@@ -839,9 +896,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
       "cpu": [
         "arm64"
       ],
@@ -852,10 +909,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
       "cpu": [
         "ppc64"
       ],
@@ -867,9 +938,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
       "cpu": [
         "riscv64"
       ],
@@ -881,9 +952,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
       "cpu": [
         "s390x"
       ],
@@ -895,9 +966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
       "cpu": [
         "x64"
       ],
@@ -909,9 +980,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
       "cpu": [
         "x64"
       ],
@@ -923,9 +994,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
       "cpu": [
         "arm64"
       ],
@@ -937,9 +1008,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
       "cpu": [
         "ia32"
       ],
@@ -951,9 +1022,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
       "cpu": [
         "x64"
       ],
@@ -1001,15 +1072,6 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.5.6",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/a11y-base/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/a11y-base/node_modules/lit": {
@@ -1076,15 +1138,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/component-base/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@vaadin/component-base/node_modules/lit": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
@@ -1127,15 +1180,6 @@
         "@vaadin/a11y-base": "~24.5.6",
         "@vaadin/component-base": "~24.5.6",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/field-base/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/field-base/node_modules/lit": {
@@ -1181,15 +1225,6 @@
         "@vaadin/vaadin-lumo-styles": "~24.5.6",
         "@vaadin/vaadin-themable-mixin": "~24.5.6",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/icon/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/icon/node_modules/@vaadin/vaadin-themable-mixin": {
@@ -1245,15 +1280,6 @@
         "@vaadin/vaadin-material-styles": "~24.5.6",
         "@vaadin/vaadin-themable-mixin": "~24.5.6",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/input-container/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/input-container/node_modules/@vaadin/vaadin-themable-mixin": {
@@ -1312,15 +1338,6 @@
         "@vaadin/vaadin-themable-mixin": "~24.5.6"
       }
     },
-    "node_modules/@vaadin/item/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@vaadin/item/node_modules/@vaadin/vaadin-themable-mixin": {
       "version": "24.5.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
@@ -1371,15 +1388,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/lit-renderer/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@vaadin/lit-renderer/node_modules/lit": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
@@ -1425,15 +1433,6 @@
         "@vaadin/vaadin-material-styles": "~24.5.6",
         "@vaadin/vaadin-themable-mixin": "~24.5.6",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@vaadin/overlay/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/overlay/node_modules/@vaadin/vaadin-themable-mixin": {
@@ -1495,15 +1494,6 @@
         "@vaadin/vaadin-themable-mixin": "~24.5.6"
       }
     },
-    "node_modules/@vaadin/vaadin-lumo-styles/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@vaadin/vaadin-lumo-styles/node_modules/@vaadin/vaadin-themable-mixin": {
       "version": "24.5.6",
       "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.5.6.tgz",
@@ -1554,15 +1544,6 @@
         "@polymer/polymer": "^3.0.0",
         "@vaadin/component-base": "~24.5.6",
         "@vaadin/vaadin-themable-mixin": "~24.5.6"
-      }
-    },
-    "node_modules/@vaadin/vaadin-material-styles/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@vaadin/vaadin-material-styles/node_modules/@vaadin/vaadin-themable-mixin": {
@@ -1616,15 +1597,6 @@
         "lit": "^3.0.0"
       }
     },
-    "node_modules/@vaadin/vaadin-themable-mixin/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/@vaadin/vaadin-themable-mixin/node_modules/lit": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
@@ -1676,9 +1648,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1854,9 +1826,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1902,32 +1874,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.13.0.tgz",
-      "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
+      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.18.0",
-        "@eslint/core": "^0.7.0",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.13.0",
-        "@eslint/plugin-kit": "^0.2.0",
-        "@humanfs/node": "^0.16.5",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.17.0",
+        "@eslint/plugin-kit": "^0.2.3",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.1",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.1.0",
-        "eslint-visitor-keys": "^4.1.0",
-        "espree": "^10.2.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1941,8 +1913,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -1963,9 +1934,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
-      "integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -1993,15 +1964,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
-      "integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.12.0",
+        "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.1.0"
+        "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2129,9 +2100,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2253,9 +2224,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2385,15 +2356,6 @@
         "lit-html": "^2.8.0"
       }
     },
-    "node_modules/lit-element/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
     "node_modules/lit-html": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
@@ -2401,15 +2363,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/lit/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -2582,13 +2535,13 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -2605,9 +2558,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2631,13 +2584,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.9",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -2659,9 +2612,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2675,22 +2628,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.0",
-        "@rollup/rollup-android-arm64": "4.24.0",
-        "@rollup/rollup-darwin-arm64": "4.24.0",
-        "@rollup/rollup-darwin-x64": "4.24.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-        "@rollup/rollup-linux-arm64-musl": "4.24.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-musl": "4.24.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-        "@rollup/rollup-win32-x64-msvc": "4.24.0",
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -2773,17 +2729,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -2800,9 +2749,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -14,17 +14,21 @@
     "url": "https://github.com/davet2001/homeassistant-energy-sankey-card"
   },
   "dependencies": {
-    "@davethompson/elec-sankey": "^1.0.0",
     "@material/mwc-icon-button": "^0.27.0",
+    "@material/mwc-list": "^0.27.0",
+    "@material/mwc-textfield": "^0.27.0",
     "@mdi/js": "^7.4.47",
+    "@vaadin/combo-box": "24.5.3",
+    "@vaadin/vaadin-themable-mixin": "24.5.3",
     "color-name": "^2.0.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "home-assistant-js-websocket": "^9.4.0",
-    "lit": "^2.8.0",
-    "memoize-one": "^6.0.0"
+    "memoize-one": "^6.0.0",
+    "sortablejs": "^1.15.6"
   },
   "devDependencies": {
+    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-typescript": "^11.1.6",
@@ -34,5 +38,17 @@
     "rollup-plugin-serve": "^2.0.3",
     "tslib": "^2.8.0",
     "typescript": "^5.5.3"
+  },
+  "overrides": {
+    "@lit/reactive-element": "1.6.3"
+  },
+  "_comment": "Polymer 3.2 contained a bug, fixed in https://github.com/Polymer/polymer/pull/5569, add as patch",
+  "resolutions": {
+    "@polymer/polymer": "patch:@polymer/polymer@3.5.2#./.yarn/patches/@polymer/polymer/pr-5569.patch",
+    "@material/mwc-button@^0.25.3": "^0.27.0",
+    "lit": "2.8.0",
+    "lit-html": "2.8.0",
+    "@fullcalendar/daygrid": "6.1.15",
+    "globals": "15.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@material/mwc-icon-button": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
+    "@material/mwc-list-item": "^0.27.0",
     "@material/mwc-textfield": "^0.27.0",
     "@mdi/js": "^7.4.47",
     "@vaadin/combo-box": "24.5.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@material/mwc-icon-button": "^0.27.0",
     "@material/mwc-list": "^0.27.0",
-    "@material/mwc-list-item": "^0.27.0",
     "@material/mwc-textfield": "^0.27.0",
     "@mdi/js": "^7.4.47",
     "@vaadin/combo-box": "24.5.3",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,6 +2,7 @@
 import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
+import alias from "@rollup/plugin-alias";
 
 const plugins = [
   typescript({
@@ -9,6 +10,29 @@ const plugins = [
   }),
   nodeResolve(),
   json(),
+  alias({
+    entries: {
+      // "lit/static-html$": "lit/static-html.js",
+      "lit/decorators": "lit/decorators.js",
+      // "lit/directive$": "lit/directive.js",
+      // "lit/directives/until$": "lit/directives/until.js",
+      // "lit/directives/class-map$": "lit/directives/class-map.js",
+      // "lit/directives/style-map$": "lit/directives/style-map.js",
+      "lit/directives/if-defined": "lit/directives/if-defined.js",
+      // "lit/directives/guard$": "lit/directives/guard.js",
+      // "lit/directives/cache$": "lit/directives/cache.js",
+      "lit/directives/repeat": "lit/directives/repeat.js",
+      // "lit/directives/live$": "lit/directives/live.js",
+      // "lit/directives/keyed$": "lit/directives/keyed.js",
+      // "lit/polyfill-support$": "lit/polyfill-support.js",
+      // "@lit-labs/virtualizer/layouts/grid":
+      //   "@lit-labs/virtualizer/layouts/grid.js",
+      // "@lit-labs/virtualizer/polyfills/resize-observer-polyfill/ResizeObserver":
+      //   "@lit-labs/virtualizer/polyfills/resize-observer-polyfill/ResizeObserver.js",
+      // "@lit-labs/observers/resize-controller":
+      //   "@lit-labs/observers/resize-controller.js",
+    },
+  }),
 ];
 
 export default {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Script to setup node.js ready for card development.
+# So far this has been used inside a homeassistant core vscode devcontainer.
+#
 # After completing setup, use
 #
 # npm run start

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,3 +2,5 @@ const PREFIX_NAME = 'energy-sankey';
 
 export const POWER_CARD_NAME = `${PREFIX_NAME}-power-flow-card`;
 export const POWER_CARD_EDITOR_NAME = `${POWER_CARD_NAME}-editor`;
+export const ENERGY_CARD_NAME = `${PREFIX_NAME}-energy-elec-flow-card`;
+export const ENERGY_CARD_EDITOR_NAME = `${ENERGY_CARD_NAME}-editor`;

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,0 +1,4 @@
+const PREFIX_NAME = 'energy-sankey';
+
+export const POWER_CARD_NAME = `${PREFIX_NAME}-power-flow-card`;
+export const POWER_CARD_EDITOR_NAME = `${POWER_CARD_NAME}-editor`;

--- a/src/energy-flow-card-editor.ts
+++ b/src/energy-flow-card-editor.ts
@@ -1,0 +1,65 @@
+import { customElement, property, state } from "lit/decorators";
+
+import { LovelaceCardEditor } from "./ha/panels/lovelace/types";
+import { EnergyElecFlowCardConfig, PowerFlowCardConfig } from "./types";
+import { html, LitElement, nothing } from "lit";
+import { HomeAssistant, LocalizeFunc } from "./ha/types";
+import { HaFormSchema } from "./utils/form/ha-form";
+import "./ha/panels/lovelace/editor/hui-entities-card-row-editor";
+import { fireEvent } from "./ha/common/dom/fire_event";
+
+import { ENERGY_CARD_EDITOR_NAME } from "./const";
+
+const schema = [
+  { name: "title", selector: { text: {} } },
+];
+
+@customElement(ENERGY_CARD_EDITOR_NAME)
+export class EnergyFlowCardEditor extends LitElement implements LovelaceCardEditor {
+
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @state() private _config?: EnergyElecFlowCardConfig;
+
+  public setConfig(config: EnergyElecFlowCardConfig): void {
+    this._config = config;
+  }
+
+  private _computeLabel = (schema: HaFormSchema) => {
+    switch (schema.name) {
+      case "title": return "Title";
+    }
+    console.error("Error name key missing for '" + schema.name + "'")
+    return ""
+  };
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const data = { ...this._config } as any;
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabel}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+      <ha-alert
+        alert-type="info"
+        .title="Note"
+      >
+        Energy flow entities are configured in the
+        <a href="/config/energy">Energy Dashboard Config</a>.
+        They cannot be modified via the card configuration.
+      </ha-alert>
+      `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    const config = ev.detail.value;
+    fireEvent(this, "config-changed", { config });
+  }
+}

--- a/src/ha/common/dom/get_main_window.ts
+++ b/src/ha/common/dom/get_main_window.ts
@@ -1,0 +1,13 @@
+import { MAIN_WINDOW_NAME } from "../../data/main_window";
+
+export const mainWindow = (() => {
+  try {
+    return window.name === MAIN_WINDOW_NAME
+      ? window
+      : parent.name === MAIN_WINDOW_NAME
+        ? parent
+        : top!;
+  } catch {
+    return window;
+  }
+})();

--- a/src/ha/common/string/compare.ts
+++ b/src/ha/common/string/compare.ts
@@ -1,0 +1,47 @@
+import memoizeOne from "memoize-one";
+
+const collator = memoizeOne(
+  (language: string | undefined) => new Intl.Collator(language)
+);
+
+const caseInsensitiveCollator = memoizeOne(
+  (language: string | undefined) =>
+    new Intl.Collator(language, { sensitivity: "accent" })
+);
+
+const fallbackStringCompare = (a: string, b: string) => {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+
+  return 0;
+};
+
+export const stringCompare = (
+  a: string,
+  b: string,
+  language: string | undefined = undefined
+) => {
+  // @ts-ignore
+  if (Intl?.Collator) {
+    return collator(language).compare(a, b);
+  }
+
+  return fallbackStringCompare(a, b);
+};
+
+export const caseInsensitiveStringCompare = (
+  a: string,
+  b: string,
+  language: string | undefined = undefined
+) => {
+  // @ts-ignore
+  if (Intl?.Collator) {
+    return caseInsensitiveCollator(language).compare(a, b);
+  }
+
+  return fallbackStringCompare(a.toLowerCase(), b.toLowerCase());
+};

--- a/src/ha/common/string/filter/char-code.ts
+++ b/src/ha/common/string/filter/char-code.ts
@@ -1,0 +1,244 @@
+// MIT License
+
+// Copyright (c) 2015 - present Microsoft Corporation
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Names from https://blog.codinghorror.com/ascii-pronunciation-rules-for-programmers/
+
+/**
+ * An inlined enum containing useful character codes (to be used with String.charCodeAt).
+ * Please leave the const keyword such that it gets inlined when compiled to JavaScript!
+ */
+export enum CharCode {
+  Null = 0,
+  /**
+   * The `\b` character.
+   */
+  Backspace = 8,
+  /**
+   * The `\t` character.
+   */
+  Tab = 9,
+  /**
+   * The `\n` character.
+   */
+  LineFeed = 10,
+  /**
+   * The `\r` character.
+   */
+  CarriageReturn = 13,
+  Space = 32,
+  /**
+   * The `!` character.
+   */
+  ExclamationMark = 33,
+  /**
+   * The `"` character.
+   */
+  DoubleQuote = 34,
+  /**
+   * The `#` character.
+   */
+  Hash = 35,
+  /**
+   * The `$` character.
+   */
+  DollarSign = 36,
+  /**
+   * The `%` character.
+   */
+  PercentSign = 37,
+  /**
+   * The `&` character.
+   */
+  Ampersand = 38,
+  /**
+   * The `'` character.
+   */
+  SingleQuote = 39,
+  /**
+   * The `(` character.
+   */
+  OpenParen = 40,
+  /**
+   * The `)` character.
+   */
+  CloseParen = 41,
+  /**
+   * The `*` character.
+   */
+  Asterisk = 42,
+  /**
+   * The `+` character.
+   */
+  Plus = 43,
+  /**
+   * The `,` character.
+   */
+  Comma = 44,
+  /**
+   * The `-` character.
+   */
+  Dash = 45,
+  /**
+   * The `.` character.
+   */
+  Period = 46,
+  /**
+   * The `/` character.
+   */
+  Slash = 47,
+
+  Digit0 = 48,
+  Digit1 = 49,
+  Digit2 = 50,
+  Digit3 = 51,
+  Digit4 = 52,
+  Digit5 = 53,
+  Digit6 = 54,
+  Digit7 = 55,
+  Digit8 = 56,
+  Digit9 = 57,
+
+  /**
+   * The `:` character.
+   */
+  Colon = 58,
+  /**
+   * The `;` character.
+   */
+  Semicolon = 59,
+  /**
+   * The `<` character.
+   */
+  LessThan = 60,
+  /**
+   * The `=` character.
+   */
+  Equals = 61,
+  /**
+   * The `>` character.
+   */
+  GreaterThan = 62,
+  /**
+   * The `?` character.
+   */
+  QuestionMark = 63,
+  /**
+   * The `@` character.
+   */
+  AtSign = 64,
+
+  A = 65,
+  B = 66,
+  C = 67,
+  D = 68,
+  E = 69,
+  F = 70,
+  G = 71,
+  H = 72,
+  I = 73,
+  J = 74,
+  K = 75,
+  L = 76,
+  M = 77,
+  N = 78,
+  O = 79,
+  P = 80,
+  Q = 81,
+  R = 82,
+  S = 83,
+  T = 84,
+  U = 85,
+  V = 86,
+  W = 87,
+  X = 88,
+  Y = 89,
+  Z = 90,
+
+  /**
+   * The `[` character.
+   */
+  OpenSquareBracket = 91,
+  /**
+   * The `\` character.
+   */
+  Backslash = 92,
+  /**
+   * The `]` character.
+   */
+  CloseSquareBracket = 93,
+  /**
+   * The `^` character.
+   */
+  Caret = 94,
+  /**
+   * The `_` character.
+   */
+  Underline = 95,
+  /**
+   * The ``(`)`` character.
+   */
+  BackTick = 96,
+
+  a = 97,
+  b = 98,
+  c = 99,
+  d = 100,
+  e = 101,
+  f = 102,
+  g = 103,
+  h = 104,
+  i = 105,
+  j = 106,
+  k = 107,
+  l = 108,
+  m = 109,
+  n = 110,
+  o = 111,
+  p = 112,
+  q = 113,
+  r = 114,
+  s = 115,
+  t = 116,
+  u = 117,
+  v = 118,
+  w = 119,
+  x = 120,
+  y = 121,
+  z = 122,
+
+  /**
+   * The `{` character.
+   */
+  OpenCurlyBrace = 123,
+  /**
+   * The `|` character.
+   */
+  Pipe = 124,
+  /**
+   * The `}` character.
+   */
+  CloseCurlyBrace = 125,
+  /**
+   * The `~` character.
+   */
+  Tilde = 126,
+}

--- a/src/ha/common/string/filter/filter.ts
+++ b/src/ha/common/string/filter/filter.ts
@@ -1,0 +1,551 @@
+/* eslint-disable no-console */
+// MIT License
+
+// Copyright (c) 2015 - present Microsoft Corporation
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { CharCode } from "./char-code";
+
+const _debug = false;
+
+export interface Match {
+  start: number;
+  end: number;
+}
+
+const _maxLen = 128;
+
+function initTable() {
+  const table: number[][] = [];
+  const row: number[] = [];
+  for (let i = 0; i <= _maxLen; i++) {
+    row[i] = 0;
+  }
+  for (let i = 0; i <= _maxLen; i++) {
+    table.push(row.slice(0));
+  }
+  return table;
+}
+
+function isSeparatorAtPos(value: string, index: number): boolean {
+  if (index < 0 || index >= value.length) {
+    return false;
+  }
+  const code = value.codePointAt(index);
+  switch (code) {
+    case CharCode.Underline:
+    case CharCode.Dash:
+    case CharCode.Period:
+    case CharCode.Space:
+    case CharCode.Slash:
+    case CharCode.Backslash:
+    case CharCode.SingleQuote:
+    case CharCode.DoubleQuote:
+    case CharCode.Colon:
+    case CharCode.DollarSign:
+    case CharCode.LessThan:
+    case CharCode.OpenParen:
+    case CharCode.OpenSquareBracket:
+      return true;
+    case undefined:
+      return false;
+    default:
+      if (isEmojiImprecise(code)) {
+        return true;
+      }
+      return false;
+  }
+}
+
+function isWhitespaceAtPos(value: string, index: number): boolean {
+  if (index < 0 || index >= value.length) {
+    return false;
+  }
+  const code = value.charCodeAt(index);
+  switch (code) {
+    case CharCode.Space:
+    case CharCode.Tab:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isUpperCaseAtPos(pos: number, word: string, wordLow: string): boolean {
+  return word[pos] !== wordLow[pos];
+}
+
+export function isPatternInWord(
+  patternLow: string,
+  patternPos: number,
+  patternLen: number,
+  wordLow: string,
+  wordPos: number,
+  wordLen: number,
+  fillMinWordPosArr = false
+): boolean {
+  while (patternPos < patternLen && wordPos < wordLen) {
+    if (patternLow[patternPos] === wordLow[wordPos]) {
+      if (fillMinWordPosArr) {
+        // Remember the min word position for each pattern position
+        _minWordMatchPos[patternPos] = wordPos;
+      }
+      patternPos += 1;
+    }
+    wordPos += 1;
+  }
+  return patternPos === patternLen; // pattern must be exhausted
+}
+
+enum Arrow {
+  Diag = 1,
+  Left = 2,
+  LeftLeft = 3,
+}
+
+/**
+ * An array representing a fuzzy match.
+ *
+ * 0. the score
+ * 1. the offset at which matching started
+ * 2. `<match_pos_N>`
+ * 3. `<match_pos_1>`
+ * 4. `<match_pos_0>` etc
+ */
+// export type FuzzyScore = [score: number, wordStart: number, ...matches: number[]];// [number, number, number];
+export type FuzzyScore = Array<number>;
+
+export function fuzzyScore(
+  pattern: string,
+  patternLow: string,
+  patternStart: number,
+  word: string,
+  wordLow: string,
+  wordStart: number,
+  firstMatchCanBeWeak: boolean
+): FuzzyScore | undefined {
+  const patternLen = pattern.length > _maxLen ? _maxLen : pattern.length;
+  const wordLen = word.length > _maxLen ? _maxLen : word.length;
+
+  if (
+    patternStart >= patternLen ||
+    wordStart >= wordLen ||
+    patternLen - patternStart > wordLen - wordStart
+  ) {
+    return undefined;
+  }
+
+  // Run a simple check if the characters of pattern occur
+  // (in order) at all in word. If that isn't the case we
+  // stop because no match will be possible
+  if (
+    !isPatternInWord(
+      patternLow,
+      patternStart,
+      patternLen,
+      wordLow,
+      wordStart,
+      wordLen,
+      true
+    )
+  ) {
+    return undefined;
+  }
+
+  // Find the max matching word position for each pattern position
+  // NOTE: the min matching word position was filled in above, in the `isPatternInWord` call
+  _fillInMaxWordMatchPos(
+    patternLen,
+    wordLen,
+    patternStart,
+    wordStart,
+    patternLow,
+    wordLow
+  );
+
+  let row: number;
+  let column = 1;
+  let patternPos: number;
+  let wordPos: number;
+
+  const hasStrongFirstMatch = [false];
+
+  // There will be a match, fill in tables
+  for (
+    row = 1, patternPos = patternStart;
+    patternPos < patternLen;
+    row++, patternPos++
+  ) {
+    // Reduce search space to possible matching word positions and to possible access from next row
+    const minWordMatchPos = _minWordMatchPos[patternPos];
+    const maxWordMatchPos = _maxWordMatchPos[patternPos];
+    const nextMaxWordMatchPos =
+      patternPos + 1 < patternLen ? _maxWordMatchPos[patternPos + 1] : wordLen;
+
+    for (
+      column = minWordMatchPos - wordStart + 1, wordPos = minWordMatchPos;
+      wordPos < nextMaxWordMatchPos;
+      column++, wordPos++
+    ) {
+      let score = Number.MIN_SAFE_INTEGER;
+      let canComeDiag = false;
+
+      if (wordPos <= maxWordMatchPos) {
+        score = _doScore(
+          pattern,
+          patternLow,
+          patternPos,
+          patternStart,
+          word,
+          wordLow,
+          wordPos,
+          wordLen,
+          wordStart,
+          _diag[row - 1][column - 1] === 0,
+          hasStrongFirstMatch
+        );
+      }
+
+      let diagScore = 0;
+      if (score !== Number.MAX_SAFE_INTEGER) {
+        canComeDiag = true;
+        diagScore = score + _table[row - 1][column - 1];
+      }
+
+      const canComeLeft = wordPos > minWordMatchPos;
+      const leftScore = canComeLeft
+        ? _table[row][column - 1] + (_diag[row][column - 1] > 0 ? -5 : 0)
+        : 0; // penalty for a gap start
+
+      const canComeLeftLeft =
+        wordPos > minWordMatchPos + 1 && _diag[row][column - 1] > 0;
+      const leftLeftScore = canComeLeftLeft
+        ? _table[row][column - 2] + (_diag[row][column - 2] > 0 ? -5 : 0)
+        : 0; // penalty for a gap start
+
+      if (
+        canComeLeftLeft &&
+        (!canComeLeft || leftLeftScore >= leftScore) &&
+        (!canComeDiag || leftLeftScore >= diagScore)
+      ) {
+        // always prefer choosing left left to jump over a diagonal because that means a match is earlier in the word
+        _table[row][column] = leftLeftScore;
+        _arrows[row][column] = Arrow.LeftLeft;
+        _diag[row][column] = 0;
+      } else if (canComeLeft && (!canComeDiag || leftScore >= diagScore)) {
+        // always prefer choosing left since that means a match is earlier in the word
+        _table[row][column] = leftScore;
+        _arrows[row][column] = Arrow.Left;
+        _diag[row][column] = 0;
+      } else if (canComeDiag) {
+        _table[row][column] = diagScore;
+        _arrows[row][column] = Arrow.Diag;
+        _diag[row][column] = _diag[row - 1][column - 1] + 1;
+      } else {
+        throw new Error(`not possible`);
+      }
+    }
+  }
+
+  if (_debug) {
+    printTables(pattern, patternStart, word, wordStart);
+  }
+
+  if (!hasStrongFirstMatch[0] && !firstMatchCanBeWeak) {
+    return undefined;
+  }
+
+  row--;
+  column--;
+
+  const result: FuzzyScore = [_table[row][column], wordStart];
+
+  let backwardsDiagLength = 0;
+  let maxMatchColumn = 0;
+
+  while (row >= 1) {
+    // Find the column where we go diagonally up
+    let diagColumn = column;
+    do {
+      const arrow = _arrows[row][diagColumn];
+      if (arrow === Arrow.LeftLeft) {
+        diagColumn -= 2;
+      } else if (arrow === Arrow.Left) {
+        diagColumn -= 1;
+      } else {
+        // found the diagonal
+        break;
+      }
+    } while (diagColumn >= 1);
+
+    // Overturn the "forwards" decision if keeping the "backwards" diagonal would give a better match
+    if (
+      backwardsDiagLength > 1 && // only if we would have a contiguous match of 3 characters
+      patternLow[patternStart + row - 1] === wordLow[wordStart + column - 1] && // only if we can do a contiguous match diagonally
+      !isUpperCaseAtPos(diagColumn + wordStart - 1, word, wordLow) && // only if the forwards chose diagonal is not an uppercase
+      backwardsDiagLength + 1 > _diag[row][diagColumn] // only if our contiguous match would be longer than the "forwards" contiguous match
+    ) {
+      diagColumn = column;
+    }
+
+    if (diagColumn === column) {
+      // this is a contiguous match
+      backwardsDiagLength++;
+    } else {
+      backwardsDiagLength = 1;
+    }
+
+    if (!maxMatchColumn) {
+      // remember the last matched column
+      maxMatchColumn = diagColumn;
+    }
+
+    row--;
+    column = diagColumn - 1;
+    result.push(column);
+  }
+
+  if (wordLen === patternLen) {
+    // the word matches the pattern with all characters!
+    // giving the score a total match boost (to come up ahead other words)
+    result[0] += 2;
+  }
+
+  // Add 1 penalty for each skipped character in the word
+  const skippedCharsCount = maxMatchColumn - patternLen;
+  result[0] -= skippedCharsCount;
+
+  return result;
+}
+
+function _doScore(
+  pattern: string,
+  patternLow: string,
+  patternPos: number,
+  patternStart: number,
+  word: string,
+  wordLow: string,
+  wordPos: number,
+  wordLen: number,
+  wordStart: number,
+  newMatchStart: boolean,
+  outFirstMatchStrong: boolean[]
+): number {
+  if (patternLow[patternPos] !== wordLow[wordPos]) {
+    return Number.MIN_SAFE_INTEGER;
+  }
+
+  let score = 1;
+  let isGapLocation = false;
+  if (wordPos === patternPos - patternStart) {
+    // common prefix: `foobar <-> foobaz`
+    //                            ^^^^^
+    score = pattern[patternPos] === word[wordPos] ? 7 : 5;
+  } else if (
+    isUpperCaseAtPos(wordPos, word, wordLow) &&
+    (wordPos === 0 || !isUpperCaseAtPos(wordPos - 1, word, wordLow))
+  ) {
+    // hitting upper-case: `foo <-> forOthers`
+    //                              ^^ ^
+    score = pattern[patternPos] === word[wordPos] ? 7 : 5;
+    isGapLocation = true;
+  } else if (
+    isSeparatorAtPos(wordLow, wordPos) &&
+    (wordPos === 0 || !isSeparatorAtPos(wordLow, wordPos - 1))
+  ) {
+    // hitting a separator: `. <-> foo.bar`
+    //                                ^
+    score = 5;
+  } else if (
+    isSeparatorAtPos(wordLow, wordPos - 1) ||
+    isWhitespaceAtPos(wordLow, wordPos - 1)
+  ) {
+    // post separator: `foo <-> bar_foo`
+    //                              ^^^
+    score = 5;
+    isGapLocation = true;
+  }
+
+  if (score > 1 && patternPos === patternStart) {
+    outFirstMatchStrong[0] = true;
+  }
+
+  if (!isGapLocation) {
+    isGapLocation =
+      isUpperCaseAtPos(wordPos, word, wordLow) ||
+      isSeparatorAtPos(wordLow, wordPos - 1) ||
+      isWhitespaceAtPos(wordLow, wordPos - 1);
+  }
+
+  //
+  if (patternPos === patternStart) {
+    // first character in pattern
+    if (wordPos > wordStart) {
+      // the first pattern character would match a word character that is not at the word start
+      // so introduce a penalty to account for the gap preceding this match
+      score -= isGapLocation ? 3 : 5;
+    }
+  } else if (newMatchStart) {
+    // this would be the beginning of a new match (i.e. there would be a gap before this location)
+    score += isGapLocation ? 2 : 0;
+  } else {
+    // this is part of a contiguous match, so give it a slight bonus, but do so only if it would not be a prefered gap location
+    score += isGapLocation ? 0 : 1;
+  }
+
+  if (wordPos + 1 === wordLen) {
+    // we always penalize gaps, but this gives unfair advantages to a match that would match the last character in the word
+    // so pretend there is a gap after the last character in the word to normalize things
+    score -= isGapLocation ? 3 : 5;
+  }
+
+  return score;
+}
+
+function printTable(
+  table: number[][],
+  pattern: string,
+  patternLen: number,
+  word: string,
+  wordLen: number
+): string {
+  function pad(s: string, n: number, _pad = " ") {
+    while (s.length < n) {
+      s = _pad + s;
+    }
+    return s;
+  }
+  let ret = ` |   |${word
+    .split("")
+    .map((c) => pad(c, 3))
+    .join("|")}\n`;
+
+  for (let i = 0; i <= patternLen; i++) {
+    if (i === 0) {
+      ret += " |";
+    } else {
+      ret += `${pattern[i - 1]}|`;
+    }
+    ret +=
+      table[i]
+        .slice(0, wordLen + 1)
+        .map((n) => pad(n.toString(), 3))
+        .join("|") + "\n";
+  }
+  return ret;
+}
+
+function printTables(
+  pattern: string,
+  patternStart: number,
+  word: string,
+  wordStart: number
+): void {
+  pattern = pattern.substr(patternStart);
+  word = word.substr(wordStart);
+  console.log(printTable(_table, pattern, pattern.length, word, word.length));
+  console.log(printTable(_arrows, pattern, pattern.length, word, word.length));
+  console.log(printTable(_diag, pattern, pattern.length, word, word.length));
+}
+
+const _minWordMatchPos = initArr(2 * _maxLen); // min word position for a certain pattern position
+const _maxWordMatchPos = initArr(2 * _maxLen); // max word position for a certain pattern position
+const _diag = initTable(); // the length of a contiguous diagonal match
+const _table = initTable();
+const _arrows = <Arrow[][]>initTable();
+
+function initArr(maxLen: number) {
+  const row: number[] = [];
+  for (let i = 0; i <= maxLen; i++) {
+    row[i] = 0;
+  }
+  return row;
+}
+
+function _fillInMaxWordMatchPos(
+  patternLen: number,
+  wordLen: number,
+  patternStart: number,
+  wordStart: number,
+  patternLow: string,
+  wordLow: string
+) {
+  let patternPos = patternLen - 1;
+  let wordPos = wordLen - 1;
+  while (patternPos >= patternStart && wordPos >= wordStart) {
+    if (patternLow[patternPos] === wordLow[wordPos]) {
+      _maxWordMatchPos[patternPos] = wordPos;
+      patternPos--;
+    }
+    wordPos--;
+  }
+}
+
+export interface FuzzyScorer {
+  (
+    pattern: string,
+    lowPattern: string,
+    patternPos: number,
+    word: string,
+    lowWord: string,
+    wordPos: number,
+    firstMatchCanBeWeak: boolean
+  ): FuzzyScore | undefined;
+}
+
+export function createMatches(score: undefined | FuzzyScore): Match[] {
+  if (typeof score === "undefined") {
+    return [];
+  }
+  const res: Match[] = [];
+  const wordPos = score[1];
+  for (let i = score.length - 1; i > 1; i--) {
+    const pos = score[i] + wordPos;
+    const last = res[res.length - 1];
+    if (last && last.end === pos) {
+      last.end = pos + 1;
+    } else {
+      res.push({ start: pos, end: pos + 1 });
+    }
+  }
+  return res;
+}
+
+/**
+ * A fast function (therefore imprecise) to check if code points are emojis.
+ * Generated using https://github.com/alexdima/unicode-utils/blob/master/generate-emoji-test.js
+ */
+export function isEmojiImprecise(x: number): boolean {
+  return (
+    (x >= 0x1f1e6 && x <= 0x1f1ff) ||
+    x === 8986 ||
+    x === 8987 ||
+    x === 9200 ||
+    x === 9203 ||
+    (x >= 9728 && x <= 10175) ||
+    x === 11088 ||
+    x === 11093 ||
+    (x >= 127744 && x <= 128591) ||
+    (x >= 128640 && x <= 128764) ||
+    (x >= 128992 && x <= 129003) ||
+    (x >= 129280 && x <= 129535) ||
+    (x >= 129648 && x <= 129750)
+  );
+}

--- a/src/ha/common/string/filter/sequence-matching.ts
+++ b/src/ha/common/string/filter/sequence-matching.ts
@@ -1,0 +1,84 @@
+import { stripDiacritics } from "../strip-diacritics";
+import { fuzzyScore } from "./filter";
+
+/**
+ * Determine whether a sequence of letters exists in another string,
+ *   in that order, allowing for skipping. Ex: "chdr" exists in "chandelier")
+ *
+ * @param {string} filter - Sequence of letters to check for
+ * @param {ScorableTextItem} item - Item against whose strings will be checked
+ *
+ * @return {number} Score representing how well the word matches the filter. Return of 0 means no match.
+ */
+
+export const fuzzySequentialMatch = (
+  filter: string,
+  item: ScorableTextItem
+) => {
+  let topScore = Number.NEGATIVE_INFINITY;
+
+  for (const word of item.strings) {
+    const scores = fuzzyScore(
+      filter,
+      stripDiacritics(filter.toLowerCase()),
+      0,
+      word,
+      stripDiacritics(word.toLowerCase()),
+      0,
+      true
+    );
+
+    if (!scores) {
+      continue;
+    }
+
+    // The VS Code implementation of filter returns a 0 for a weak match.
+    // But if .filter() sees a "0", it considers that a failed match and will remove it.
+    // So, we set score to 1 in these cases so the match will be included, and mostly respect correct ordering.
+    const score = scores[0] === 0 ? 1 : scores[0];
+
+    if (score > topScore) {
+      topScore = score;
+    }
+  }
+
+  if (topScore === Number.NEGATIVE_INFINITY) {
+    return undefined;
+  }
+
+  return topScore;
+};
+
+/**
+ * An interface that objects must extend in order to use the fuzzy sequence matcher
+ *
+ * @param {number} score - A number representing the existence and strength of a match.
+ *    - `< 0` means a good match that starts in the middle of the string
+ *    - `> 0` means a good match that starts at the beginning of the string
+ *    - `0` means just barely a match
+ *    - `undefined` means not a match
+ *
+ * @param {string} strings - Array of strings (aliases) representing the item. The filter string will be compared against each of these for a match.
+ *
+ */
+
+export interface ScorableTextItem {
+  score?: number;
+  strings: string[];
+}
+
+type FuzzyFilterSort = <T extends ScorableTextItem>(
+  filter: string,
+  items: T[]
+) => T[];
+
+export const fuzzyFilterSort: FuzzyFilterSort = (filter, items) =>
+  items
+    .map((item) => {
+      item.score = fuzzySequentialMatch(filter, item);
+      return item;
+    })
+    .filter((item) => item.score !== undefined)
+    .sort(({ score: scoreA = 0 }, { score: scoreB = 0 }) =>
+      scoreA > scoreB ? -1 : scoreA < scoreB ? 1 : 0
+    );

--- a/src/ha/common/string/strip-diacritics.ts
+++ b/src/ha/common/string/strip-diacritics.ts
@@ -1,0 +1,2 @@
+export const stripDiacritics = (str: string) =>
+  str.normalize("NFD").replace(/[\u0300-\u036F]/g, "");

--- a/src/ha/components/entity/ha-entity-picker.ts
+++ b/src/ha/components/entity/ha-entity-picker.ts
@@ -1,0 +1,429 @@
+import "../ha-list-item";
+import type { HassEntity } from "home-assistant-js-websocket";
+import type { PropertyValues, TemplateResult } from "lit";
+import { html, LitElement } from "lit";
+import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
+import { customElement, property, query, state } from "lit/decorators";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "../../common/dom/fire_event";
+import { computeDomain } from "../../common/entity/compute_domain";
+import { computeStateName } from "../../common/entity/compute_state_name";
+import type { ScorableTextItem } from "../../common/string/filter/sequence-matching";
+import { fuzzyFilterSort } from "../../common/string/filter/sequence-matching";
+import type { ValueChangedEvent, HomeAssistant } from "../../types";
+import "../ha-combo-box";
+import type { HaComboBox } from "../ha-combo-box";
+import "../ha-icon-button";
+import "../ha-svg-icon";
+// import "./state-badge";
+import { caseInsensitiveStringCompare } from "../../common/string/compare";
+// import { showHelperDetailDialog } from "../../panels/config/helpers/show-dialog-helper-detail";
+import { domainToName } from "../../data/integration";
+// import type { HelperDomain } from "../../panels/config/helpers/const";
+// import { isHelperDomain } from "../../panels/config/helpers/const";
+
+interface HassEntityWithCachedName extends HassEntity, ScorableTextItem {
+  friendly_name: string;
+}
+
+export type HaEntityPickerEntityFilterFunc = (entity: HassEntity) => boolean;
+
+const CREATE_ID = "___create-new-entity___";
+
+@customElement("ha-entity-picker")
+export class HaEntityPicker extends LitElement {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  @property({ type: Boolean }) public autofocus = false;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = false;
+
+  @property({ type: Boolean, attribute: "allow-custom-entity" })
+  public allowCustomEntity;
+
+  @property() public label?: string;
+
+  @property() public value?: string;
+
+  @property() public helper?: string;
+
+  @property({ type: Array }) public createDomains?: string[];
+
+  /**
+   * Show entities from specific domains.
+   * @type {Array}
+   * @attr include-domains
+   */
+  @property({ type: Array, attribute: "include-domains" })
+  public includeDomains?: string[];
+
+  /**
+   * Show no entities of these domains.
+   * @type {Array}
+   * @attr exclude-domains
+   */
+  @property({ type: Array, attribute: "exclude-domains" })
+  public excludeDomains?: string[];
+
+  /**
+   * Show only entities of these device classes.
+   * @type {Array}
+   * @attr include-device-classes
+   */
+  @property({ type: Array, attribute: "include-device-classes" })
+  public includeDeviceClasses?: string[];
+
+  /**
+   * Show only entities with these unit of measuments.
+   * @type {Array}
+   * @attr include-unit-of-measurement
+   */
+  @property({ type: Array, attribute: "include-unit-of-measurement" })
+  public includeUnitOfMeasurement?: string[];
+
+  /**
+   * List of allowed entities to show.
+   * @type {Array}
+   * @attr include-entities
+   */
+  @property({ type: Array, attribute: "include-entities" })
+  public includeEntities?: string[];
+
+  /**
+   * List of entities to be excluded.
+   * @type {Array}
+   * @attr exclude-entities
+   */
+  @property({ type: Array, attribute: "exclude-entities" })
+  public excludeEntities?: string[];
+
+  @property({ attribute: false })
+  public entityFilter?: HaEntityPickerEntityFilterFunc;
+
+  @property({ type: Boolean }) public hideClearIcon = false;
+
+  @property({ attribute: "item-label-path" }) public itemLabelPath =
+    "friendly_name";
+
+  @state() private _opened = false;
+
+  @query("ha-combo-box", true) public comboBox!: HaComboBox;
+
+  public async open() {
+    await this.updateComplete;
+    await this.comboBox?.open();
+  }
+
+  public async focus() {
+    await this.updateComplete;
+    await this.comboBox?.focus();
+  }
+
+  private _initedStates = false;
+
+  private _states: HassEntityWithCachedName[] = [];
+
+  private _rowRenderer: ComboBoxLitRenderer<HassEntityWithCachedName> = (
+    item
+  ) =>
+    html`<ha-list-item graphic="avatar" .twoline=${!!item.entity_id}>
+      ${item.state
+        ? html`<state-badge
+            slot="graphic"
+            .stateObj=${item}
+            .hass=${this.hass}
+          ></state-badge>`
+        : ""}
+      <span>${item.friendly_name}</span>
+      <span slot="secondary"
+        >${item.entity_id.startsWith(CREATE_ID)
+        ? this.hass.localize("ui.components.entity.entity-picker.new_entity")
+        : item.entity_id}</span
+      >
+    </ha-list-item>`;
+
+  private _getStates = memoizeOne(
+    (
+      _opened: boolean,
+      hass: this["hass"],
+      includeDomains: this["includeDomains"],
+      excludeDomains: this["excludeDomains"],
+      entityFilter: this["entityFilter"],
+      includeDeviceClasses: this["includeDeviceClasses"],
+      includeUnitOfMeasurement: this["includeUnitOfMeasurement"],
+      includeEntities: this["includeEntities"],
+      excludeEntities: this["excludeEntities"],
+      createDomains: this["createDomains"]
+    ): HassEntityWithCachedName[] => {
+      let states: HassEntityWithCachedName[] = [];
+
+      if (!hass) {
+        return [];
+      }
+      let entityIds = Object.keys(hass.states);
+
+      const createItems = createDomains?.length
+        ? createDomains.map((domain) => {
+          const newFriendlyName = hass.localize(
+            "ui.components.entity.entity-picker.create_helper",
+            {
+              domain: /*isHelperDomain(domain)
+                ? hass.localize(
+                  `ui.panel.config.helpers.types.${domain as HelperDomain}`
+                )
+                :  domainToName(hass.localize, */domain /*)*/,
+            }
+          );
+
+          return {
+            entity_id: CREATE_ID + domain,
+            state: "on",
+            last_changed: "",
+            last_updated: "",
+            context: { id: "", user_id: null, parent_id: null },
+            friendly_name: newFriendlyName,
+            attributes: {
+              icon: "mdi:plus",
+            },
+            strings: [domain, newFriendlyName],
+          };
+        })
+        : [];
+
+      if (!entityIds.length) {
+        return [
+          {
+            entity_id: "",
+            state: "",
+            last_changed: "",
+            last_updated: "",
+            context: { id: "", user_id: null, parent_id: null },
+            friendly_name: this.hass!.localize(
+              "ui.components.entity.entity-picker.no_entities"
+            ),
+            attributes: {
+              friendly_name: this.hass!.localize(
+                "ui.components.entity.entity-picker.no_entities"
+              ),
+              icon: "mdi:magnify",
+            },
+            strings: [],
+          },
+          ...createItems,
+        ];
+      }
+
+      if (includeEntities) {
+        entityIds = entityIds.filter((entityId) =>
+          includeEntities.includes(entityId)
+        );
+      }
+
+      if (excludeEntities) {
+        entityIds = entityIds.filter(
+          (entityId) => !excludeEntities.includes(entityId)
+        );
+      }
+
+      if (includeDomains) {
+        entityIds = entityIds.filter((eid) =>
+          includeDomains.includes(computeDomain(eid))
+        );
+      }
+
+      if (excludeDomains) {
+        entityIds = entityIds.filter(
+          (eid) => !excludeDomains.includes(computeDomain(eid))
+        );
+      }
+
+      states = entityIds
+        .map((key) => {
+          const friendly_name = computeStateName(hass!.states[key]) || key;
+          return {
+            ...hass!.states[key],
+            friendly_name,
+            strings: [key, friendly_name],
+          };
+        })
+        .sort((entityA, entityB) =>
+          caseInsensitiveStringCompare(
+            entityA.friendly_name,
+            entityB.friendly_name,
+            this.hass.locale.language
+          )
+        );
+
+      if (includeDeviceClasses) {
+        states = states.filter(
+          (stateObj) =>
+            // We always want to include the entity of the current value
+            stateObj.entity_id === this.value ||
+            (stateObj.attributes.device_class &&
+              includeDeviceClasses.includes(stateObj.attributes.device_class))
+        );
+      }
+
+      if (includeUnitOfMeasurement) {
+        states = states.filter(
+          (stateObj) =>
+            // We always want to include the entity of the current value
+            stateObj.entity_id === this.value ||
+            (stateObj.attributes.unit_of_measurement &&
+              includeUnitOfMeasurement.includes(
+                stateObj.attributes.unit_of_measurement
+              ))
+        );
+      }
+
+      if (entityFilter) {
+        states = states.filter(
+          (stateObj) =>
+            // We always want to include the entity of the current value
+            stateObj.entity_id === this.value || entityFilter!(stateObj)
+        );
+      }
+
+      if (!states.length) {
+        return [
+          {
+            entity_id: "",
+            state: "",
+            last_changed: "",
+            last_updated: "",
+            context: { id: "", user_id: null, parent_id: null },
+            friendly_name: this.hass!.localize(
+              "ui.components.entity.entity-picker.no_match"
+            ),
+            attributes: {
+              friendly_name: this.hass!.localize(
+                "ui.components.entity.entity-picker.no_match"
+              ),
+              icon: "mdi:magnify",
+            },
+            strings: [],
+          },
+          ...createItems,
+        ];
+      }
+
+      if (createItems?.length) {
+        states.push(...createItems);
+      }
+
+      return states;
+    }
+  );
+
+  protected shouldUpdate(changedProps: PropertyValues) {
+    if (
+      changedProps.has("value") ||
+      changedProps.has("label") ||
+      changedProps.has("disabled")
+    ) {
+      return true;
+    }
+    return !(!changedProps.has("_opened") && this._opened);
+  }
+
+  public willUpdate(changedProps: PropertyValues) {
+    if (!this._initedStates || (changedProps.has("_opened") && this._opened)) {
+      this._states = this._getStates(
+        this._opened,
+        this.hass,
+        this.includeDomains,
+        this.excludeDomains,
+        this.entityFilter,
+        this.includeDeviceClasses,
+        this.includeUnitOfMeasurement,
+        this.includeEntities,
+        this.excludeEntities,
+        this.createDomains
+      );
+      if (this._initedStates) {
+        this.comboBox.filteredItems = this._states;
+      }
+      this._initedStates = true;
+    }
+
+    // if (changedProps.has("createDomains") && this.createDomains?.length) {
+    //   this.hass.loadFragmentTranslation("config");
+    // }
+  }
+
+  protected render(): TemplateResult {
+    return html`
+      <ha-combo-box
+        item-value-path="entity_id"
+        .itemLabelPath=${this.itemLabelPath}
+        .hass=${this.hass}
+        .value=${this._value}
+        .label=${this.label === undefined
+        ? this.hass.localize("ui.components.entity.entity-picker.entity")
+        : this.label}
+        .helper=${this.helper}
+        .allowCustomValue=${this.allowCustomEntity}
+        .filteredItems=${this._states}
+        .renderer=${this._rowRenderer}
+        .required=${this.required}
+        .disabled=${this.disabled}
+        @opened-changed=${this._openedChanged}
+        @value-changed=${this._valueChanged}
+        @filter-changed=${this._filterChanged}
+      >
+      </ha-combo-box>
+    `;
+  }
+
+  private get _value() {
+    return this.value || "";
+  }
+
+  private _openedChanged(ev: ValueChangedEvent<boolean>) {
+    this._opened = ev.detail.value;
+  }
+
+  private _valueChanged(ev: ValueChangedEvent<string | undefined>) {
+    ev.stopPropagation();
+    const newValue = ev.detail.value?.trim();
+
+    // if (newValue && newValue.startsWith(CREATE_ID)) {
+    //   const domain = newValue.substring(CREATE_ID.length);
+    //   showHelperDetailDialog(this, {
+    //     domain,
+    //     dialogClosedCallback: (item) => {
+    //       if (item.entityId) this._setValue(item.entityId);
+    //     },
+    //   });
+    //   return;
+    // }
+
+    if (newValue !== this._value) {
+      this._setValue(newValue);
+    }
+  }
+
+  private _filterChanged(ev: CustomEvent): void {
+    const target = ev.target as HaComboBox;
+    const filterString = ev.detail.value.trim().toLowerCase();
+    target.filteredItems = filterString.length
+      ? fuzzyFilterSort<HassEntityWithCachedName>(filterString, this._states)
+      : this._states;
+  }
+
+  private _setValue(value: string | undefined) {
+    this.value = value;
+    setTimeout(() => {
+      fireEvent(this, "value-changed", { value });
+      fireEvent(this, "change");
+    }, 0);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-entity-picker": HaEntityPicker;
+  }
+}

--- a/src/ha/components/ha-combo-box.ts
+++ b/src/ha/components/ha-combo-box.ts
@@ -1,0 +1,383 @@
+import { mdiClose, mdiMenuDown, mdiMenuUp } from "@mdi/js";
+import type { ComboBoxLitRenderer } from "@vaadin/combo-box/lit";
+import { comboBoxRenderer } from "@vaadin/combo-box/lit";
+import "@vaadin/combo-box/theme/material/vaadin-combo-box-light";
+import type {
+  ComboBoxDataProvider,
+  ComboBoxLight,
+  ComboBoxLightFilterChangedEvent,
+  ComboBoxLightOpenedChangedEvent,
+  ComboBoxLightValueChangedEvent,
+} from "@vaadin/combo-box/vaadin-combo-box-light";
+import { registerStyles } from "@vaadin/vaadin-themable-mixin/register-styles";
+import type { CSSResultGroup, TemplateResult } from "lit";
+import { css, html, LitElement } from "lit";
+import { customElement, property, query } from "lit/decorators";
+import { ifDefined } from "lit/directives/if-defined";
+import { fireEvent } from "../common/dom/fire_event";
+import type { HomeAssistant } from "../types";
+import "./ha-icon-button";
+import "./ha-list-item";
+import "./ha-textfield";
+import type { HaTextField } from "./ha-textfield";
+
+registerStyles(
+  "vaadin-combo-box-item",
+  css`
+    :host {
+      padding: 0 !important;
+    }
+    :host([focused]:not([disabled])) {
+      background-color: rgba(var(--rgb-primary-text-color, 0, 0, 0), 0.12);
+    }
+    :host([selected]:not([disabled])) {
+      background-color: transparent;
+      color: var(--mdc-theme-primary);
+      --mdc-ripple-color: var(--mdc-theme-primary);
+      --mdc-theme-text-primary-on-background: var(--mdc-theme-primary);
+    }
+    :host([selected]:not([disabled])):before {
+      background-color: var(--mdc-theme-primary);
+      opacity: 0.12;
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+    :host([selected][focused]:not([disabled])):before {
+      opacity: 0.24;
+    }
+    :host(:hover:not([disabled])) {
+      background-color: transparent;
+    }
+    [part="content"] {
+      width: 100%;
+    }
+    [part="checkmark"] {
+      display: none;
+    }
+  `
+);
+
+@customElement("ha-combo-box")
+export class HaComboBox extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property() public label?: string;
+
+  @property() public value?: string;
+
+  @property() public placeholder?: string;
+
+  @property() public validationMessage?: string;
+
+  @property() public helper?: string;
+
+  @property({ attribute: "error-message" }) public errorMessage?: string;
+
+  @property({ type: Boolean }) public invalid = false;
+
+  @property({ type: Boolean }) public icon = false;
+
+  @property({ attribute: false }) public items?: any[];
+
+  @property({ attribute: false }) public filteredItems?: any[];
+
+  @property({ attribute: false })
+  public dataProvider?: ComboBoxDataProvider<any>;
+
+  @property({ attribute: "allow-custom-value", type: Boolean })
+  public allowCustomValue = false;
+
+  @property({ attribute: "item-value-path" }) public itemValuePath = "value";
+
+  @property({ attribute: "item-label-path" }) public itemLabelPath = "label";
+
+  @property({ attribute: "item-id-path" }) public itemIdPath?: string;
+
+  @property({ attribute: false }) public renderer?: ComboBoxLitRenderer<any>;
+
+  @property({ type: Boolean }) public disabled = false;
+
+  @property({ type: Boolean }) public required = false;
+
+  @property({ type: Boolean, reflect: true }) public opened = false;
+
+  @query("vaadin-combo-box-light", true) private _comboBox!: ComboBoxLight;
+
+  @query("ha-textfield", true) private _inputElement!: HaTextField;
+
+  private _overlayMutationObserver?: MutationObserver;
+
+  private _bodyMutationObserver?: MutationObserver;
+
+  public async open() {
+    await this.updateComplete;
+    this._comboBox?.open();
+  }
+
+  public async focus() {
+    await this.updateComplete;
+    await this._inputElement?.updateComplete;
+    this._inputElement?.focus();
+  }
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._overlayMutationObserver) {
+      this._overlayMutationObserver.disconnect();
+      this._overlayMutationObserver = undefined;
+    }
+    if (this._bodyMutationObserver) {
+      this._bodyMutationObserver.disconnect();
+      this._bodyMutationObserver = undefined;
+    }
+  }
+
+  public get selectedItem() {
+    return this._comboBox.selectedItem;
+  }
+
+  public setInputValue(value: string) {
+    this._comboBox.value = value;
+  }
+
+  protected render(): TemplateResult {
+    return html`
+      <!-- @ts-ignore Tag definition is not included in theme folder -->
+      <vaadin-combo-box-light
+        .itemValuePath=${this.itemValuePath}
+        .itemIdPath=${this.itemIdPath}
+        .itemLabelPath=${this.itemLabelPath}
+        .items=${this.items}
+        .value=${this.value || ""}
+        .filteredItems=${this.filteredItems}
+        .dataProvider=${this.dataProvider}
+        .allowCustomValue=${this.allowCustomValue}
+        .disabled=${this.disabled}
+        .required=${this.required}
+        ${comboBoxRenderer(this.renderer || this._defaultRowRenderer)}
+        @opened-changed=${this._openedChanged}
+        @filter-changed=${this._filterChanged}
+        @value-changed=${this._valueChanged}
+        attr-for-value="value"
+      >
+        <ha-textfield
+          label=${ifDefined(this.label)}
+          placeholder=${ifDefined(this.placeholder)}
+          ?disabled=${this.disabled}
+          ?required=${this.required}
+          validationMessage=${ifDefined(this.validationMessage)}
+          .errorMessage=${this.errorMessage}
+          class="input"
+          autocapitalize="none"
+          autocomplete="off"
+          autocorrect="off"
+          input-spellcheck="false"
+          .suffix=${html`<div
+            style="width: 28px;"
+            role="none presentation"
+          ></div>`}
+          .icon=${this.icon}
+          .invalid=${this.invalid}
+          .helper=${this.helper}
+          helperPersistent
+        >
+          <slot name="icon" slot="leadingIcon"></slot>
+        </ha-textfield>
+        ${this.value
+        ? html`<ha-svg-icon
+              role="button"
+              tabindex="-1"
+              aria-label=${ifDefined(this.hass?.localize("ui.common.clear"))}
+              class="clear-button"
+              .path=${mdiClose}
+              @click=${this._clearValue}
+            ></ha-svg-icon>`
+        : ""}
+        <ha-svg-icon
+          role="button"
+          tabindex="-1"
+          aria-label=${ifDefined(this.label)}
+          aria-expanded=${this.opened ? "true" : "false"}
+          class="toggle-button"
+          .path=${this.opened ? mdiMenuUp : mdiMenuDown}
+          @click=${this._toggleOpen}
+        ></ha-svg-icon>
+      </vaadin-combo-box-light>
+    `;
+  }
+
+  private _defaultRowRenderer: ComboBoxLitRenderer<
+    string | Record<string, any>
+  > = (item) =>
+      html`<ha-list-item>
+      ${this.itemLabelPath ? item[this.itemLabelPath] : item}
+    </ha-list-item>`;
+
+  private _clearValue(ev: Event) {
+    ev.stopPropagation();
+    fireEvent(this, "value-changed", { value: undefined });
+  }
+
+  private _toggleOpen(ev: Event) {
+    if (this.opened) {
+      this._comboBox?.close();
+      ev.stopPropagation();
+    } else {
+      this._comboBox?.inputElement.focus();
+    }
+  }
+
+  private _openedChanged(ev: ComboBoxLightOpenedChangedEvent) {
+    ev.stopPropagation();
+    const opened = ev.detail.value;
+    // delay this so we can handle click event for toggle button before setting _opened
+    setTimeout(() => {
+      this.opened = opened;
+    }, 0);
+    fireEvent(this, "opened-changed", { value: ev.detail.value });
+
+    if (opened) {
+      const overlay = document.querySelector<HTMLElement>(
+        "vaadin-combo-box-overlay"
+      );
+
+      if (overlay) {
+        this._removeInert(overlay);
+      }
+      this._observeBody();
+    } else {
+      this._bodyMutationObserver?.disconnect();
+      this._bodyMutationObserver = undefined;
+    }
+  }
+
+  private _observeBody() {
+    if ("MutationObserver" in window && !this._bodyMutationObserver) {
+      this._bodyMutationObserver = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeName === "VAADIN-COMBO-BOX-OVERLAY") {
+              this._removeInert(node as HTMLElement);
+            }
+          });
+          mutation.removedNodes.forEach((node) => {
+            if (node.nodeName === "VAADIN-COMBO-BOX-OVERLAY") {
+              this._overlayMutationObserver?.disconnect();
+              this._overlayMutationObserver = undefined;
+            }
+          });
+        });
+      });
+
+      this._bodyMutationObserver.observe(document.body, {
+        childList: true,
+      });
+    }
+  }
+
+  private _removeInert(overlay: HTMLElement) {
+    if (overlay.inert) {
+      overlay.inert = false;
+      this._overlayMutationObserver?.disconnect();
+      this._overlayMutationObserver = undefined;
+      return;
+    }
+    if ("MutationObserver" in window && !this._overlayMutationObserver) {
+      this._overlayMutationObserver = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          if (mutation.attributeName === "inert") {
+            const target = mutation.target as HTMLElement;
+            if (target.inert) {
+              this._overlayMutationObserver?.disconnect();
+              this._overlayMutationObserver = undefined;
+              target.inert = false;
+            }
+          }
+        });
+      });
+
+      this._overlayMutationObserver.observe(overlay, {
+        attributes: true,
+      });
+    }
+  }
+
+  private _filterChanged(ev: ComboBoxLightFilterChangedEvent) {
+    ev.stopPropagation();
+    fireEvent(this, "filter-changed", { value: ev.detail.value });
+  }
+
+  private _valueChanged(ev: ComboBoxLightValueChangedEvent) {
+    ev.stopPropagation();
+    if (!this.allowCustomValue) {
+      // @ts-ignore
+      this._comboBox._closeOnBlurIsPrevented = true;
+    }
+    const newValue = ev.detail.value;
+
+    if (newValue !== this.value) {
+      fireEvent(this, "value-changed", { value: newValue || undefined });
+    }
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: block;
+        width: 100%;
+      }
+      vaadin-combo-box-light {
+        position: relative;
+        --vaadin-combo-box-overlay-max-height: calc(45vh - 56px);
+      }
+      ha-textfield {
+        width: 100%;
+      }
+      ha-textfield > ha-icon-button {
+        --mdc-icon-button-size: 24px;
+        padding: 2px;
+        color: var(--secondary-text-color);
+      }
+      ha-svg-icon {
+        color: var(--input-dropdown-icon-color);
+        position: absolute;
+        cursor: pointer;
+      }
+      .toggle-button {
+        right: 12px;
+        top: -10px;
+        inset-inline-start: initial;
+        inset-inline-end: 12px;
+        direction: var(--direction);
+      }
+      :host([opened]) .toggle-button {
+        color: var(--primary-color);
+      }
+      .clear-button {
+        --mdc-icon-size: 20px;
+        top: -7px;
+        right: 36px;
+        inset-inline-start: initial;
+        inset-inline-end: 36px;
+        direction: var(--direction);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-combo-box": HaComboBox;
+  }
+}
+
+declare global {
+  interface HASSDomEvents {
+    "filter-changed": { value: string };
+    "opened-changed": { value: boolean };
+  }
+}

--- a/src/ha/components/ha-list-item.ts
+++ b/src/ha/components/ha-list-item.ts
@@ -1,0 +1,116 @@
+import { ListItemBase } from "@material/mwc-list/mwc-list-item-base";
+import { styles } from "@material/mwc-list/mwc-list-item.css";
+import type { CSSResultGroup } from "lit";
+import { css } from "lit";
+import { customElement } from "lit/decorators";
+
+@customElement("ha-list-item")
+export class HaListItem extends ListItemBase {
+  protected renderRipple() {
+    if (this.noninteractive) {
+      return "";
+    }
+    return super.renderRipple();
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      styles,
+      css`
+        :host {
+          padding-left: var(
+            --mdc-list-side-padding-left,
+            var(--mdc-list-side-padding, 20px)
+          );
+          padding-inline-start: var(
+            --mdc-list-side-padding-left,
+            var(--mdc-list-side-padding, 20px)
+          );
+          padding-right: var(
+            --mdc-list-side-padding-right,
+            var(--mdc-list-side-padding, 20px)
+          );
+          padding-inline-end: var(
+            --mdc-list-side-padding-right,
+            var(--mdc-list-side-padding, 20px)
+          );
+        }
+        :host([graphic="avatar"]:not([twoLine])),
+        :host([graphic="icon"]:not([twoLine])) {
+          height: 48px;
+        }
+        span.material-icons:first-of-type {
+          margin-inline-start: 0px !important;
+          margin-inline-end: var(
+            --mdc-list-item-graphic-margin,
+            16px
+          ) !important;
+          direction: var(--direction) !important;
+        }
+        span.material-icons:last-of-type {
+          margin-inline-start: auto !important;
+          margin-inline-end: 0px !important;
+          direction: var(--direction) !important;
+        }
+        .mdc-deprecated-list-item__meta {
+          display: var(--mdc-list-item-meta-display);
+          align-items: center;
+          flex-shrink: 0;
+        }
+        :host([graphic="icon"]:not([twoline]))
+          .mdc-deprecated-list-item__graphic {
+          margin-inline-end: var(
+            --mdc-list-item-graphic-margin,
+            20px
+          ) !important;
+        }
+        :host([multiline-secondary]) {
+          height: auto;
+        }
+        :host([multiline-secondary]) .mdc-deprecated-list-item__text {
+          padding: 8px 0;
+        }
+        :host([multiline-secondary]) .mdc-deprecated-list-item__secondary-text {
+          text-overflow: initial;
+          white-space: normal;
+          overflow: auto;
+          display: inline-block;
+          margin-top: 10px;
+        }
+        :host([multiline-secondary]) .mdc-deprecated-list-item__primary-text {
+          margin-top: 10px;
+        }
+        :host([multiline-secondary])
+          .mdc-deprecated-list-item__secondary-text::before {
+          display: none;
+        }
+        :host([multiline-secondary])
+          .mdc-deprecated-list-item__primary-text::before {
+          display: none;
+        }
+        :host([disabled]) {
+          color: var(--disabled-text-color);
+        }
+        :host([noninteractive]) {
+          pointer-events: unset;
+        }
+      `,
+      // safari workaround - must be explicit
+      document.dir === "rtl"
+        ? css`
+            span.material-icons:first-of-type,
+            span.material-icons:last-of-type {
+              direction: rtl !important;
+              --direction: rtl;
+            }
+          `
+        : css``,
+    ];
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-list-item": HaListItem;
+  }
+}

--- a/src/ha/components/ha-sortable.ts
+++ b/src/ha/components/ha-sortable.ts
@@ -1,0 +1,219 @@
+/* eslint-disable lit/prefer-static-styles */
+import type { PropertyValues } from "lit";
+import { html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators";
+import type { SortableEvent } from "sortablejs";
+import { fireEvent } from "../common/dom/fire_event";
+import type { SortableInstance } from "../resources/sortable";
+
+declare global {
+  interface HASSDomEvents {
+    "item-moved": {
+      oldIndex: number;
+      newIndex: number;
+    };
+    "item-added": {
+      index: number;
+      data: any;
+    };
+    "item-removed": {
+      index: number;
+    };
+    "drag-start": undefined;
+    "drag-end": undefined;
+  }
+}
+
+export type HaSortableOptions = Omit<
+  SortableInstance.SortableOptions,
+  "onStart" | "onChoose" | "onEnd" | "onUpdate" | "onAdd" | "onRemove"
+>;
+
+@customElement("ha-sortable")
+export class HaSortable extends LitElement {
+  private _sortable?: SortableInstance;
+
+  @property({ type: Boolean })
+  public disabled = false;
+
+  @property({ type: Boolean, attribute: "no-style" })
+  public noStyle: boolean = false;
+
+  @property({ type: String, attribute: "draggable-selector" })
+  public draggableSelector?: string;
+
+  @property({ type: String, attribute: "handle-selector" })
+  public handleSelector?: string;
+
+  /**
+   * Selectors that do not lead to dragging (String or Function)
+   * https://github.com/SortableJS/Sortable?tab=readme-ov-file#filter-option
+   * */
+  @property({ type: String, attribute: "filter" })
+  public filter?: string;
+
+  @property({ type: String })
+  public group?: string | SortableInstance.GroupOptions;
+
+  @property({ type: Boolean, attribute: "invert-swap" })
+  public invertSwap: boolean = false;
+
+  @property({ attribute: false })
+  public options?: HaSortableOptions;
+
+  @property({ type: Boolean })
+  public rollback: boolean = true;
+
+  protected updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("disabled")) {
+      if (this.disabled) {
+        this._destroySortable();
+      } else {
+        this._createSortable();
+      }
+    }
+  }
+
+  // Workaround for connectedCallback just after disconnectedCallback (when dragging sortable with sortable children)
+  private _shouldBeDestroy = false;
+
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this._shouldBeDestroy = true;
+    setTimeout(() => {
+      if (this._shouldBeDestroy) {
+        this._destroySortable();
+        this._shouldBeDestroy = false;
+      }
+    }, 1);
+  }
+
+  public connectedCallback() {
+    super.connectedCallback();
+    this._shouldBeDestroy = false;
+    if (this.hasUpdated && !this.disabled) {
+      this._createSortable();
+    }
+  }
+
+  protected createRenderRoot() {
+    return this;
+  }
+
+  protected render() {
+    if (this.noStyle) return nothing;
+    return html`
+      <style>
+        .sortable-fallback {
+          display: none !important;
+        }
+
+        .sortable-ghost {
+          box-shadow: 0 0 0 2px var(--primary-color);
+          background: rgba(var(--rgb-primary-color), 0.25);
+          border-radius: 4px;
+          opacity: 0.4;
+        }
+
+        .sortable-drag {
+          border-radius: 4px;
+          opacity: 1;
+          background: var(--card-background-color);
+          box-shadow: 0px 4px 8px 3px #00000026;
+          cursor: grabbing;
+        }
+      </style>
+    `;
+  }
+
+  private async _createSortable() {
+    if (this._sortable) return;
+    const container = this.children[0] as HTMLElement | undefined;
+
+    if (!container) return;
+
+    const Sortable = (await import("../resources/sortable")).default;
+
+    const options: SortableInstance.Options = {
+      scroll: true,
+      // Force the autoscroll fallback because it works better than the native one
+      forceAutoScrollFallback: true,
+      scrollSpeed: 20,
+      animation: 150,
+      ...this.options,
+      onChoose: this._handleChoose,
+      onStart: this._handleStart,
+      onEnd: this._handleEnd,
+      onUpdate: this._handleUpdate,
+      onAdd: this._handleAdd,
+      onRemove: this._handleRemove,
+    };
+
+    if (this.draggableSelector) {
+      options.draggable = this.draggableSelector;
+    }
+    if (this.handleSelector) {
+      options.handle = this.handleSelector;
+    }
+    if (this.invertSwap !== undefined) {
+      options.invertSwap = this.invertSwap;
+    }
+    if (this.group) {
+      options.group = this.group;
+    }
+    if (this.filter) {
+      options.filter = this.filter;
+    }
+
+    this._sortable = new Sortable(container, options);
+  }
+
+  private _handleUpdate = (evt) => {
+    fireEvent(this, "item-moved", {
+      newIndex: evt.newIndex,
+      oldIndex: evt.oldIndex,
+    });
+  };
+
+  private _handleAdd = (evt) => {
+    fireEvent(this, "item-added", {
+      index: evt.newIndex,
+      data: evt.item.sortableData,
+    });
+  };
+
+  private _handleRemove = (evt) => {
+    fireEvent(this, "item-removed", { index: evt.oldIndex });
+  };
+
+  private _handleEnd = async (evt) => {
+    fireEvent(this, "drag-end");
+    // put back in original location
+    if (this.rollback && (evt.item as any).placeholder) {
+      (evt.item as any).placeholder.replaceWith(evt.item);
+      delete (evt.item as any).placeholder;
+    }
+  };
+
+  private _handleStart = () => {
+    fireEvent(this, "drag-start");
+  };
+
+  private _handleChoose = (evt: SortableEvent) => {
+    if (!this.rollback) return;
+    (evt.item as any).placeholder = document.createComment("sort-placeholder");
+    evt.item.after((evt.item as any).placeholder);
+  };
+
+  private _destroySortable() {
+    if (!this._sortable) return;
+    this._sortable.destroy();
+    this._sortable = undefined;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-sortable": HaSortable;
+  }
+}

--- a/src/ha/components/ha-textfield.ts
+++ b/src/ha/components/ha-textfield.ts
@@ -1,0 +1,231 @@
+import { TextFieldBase } from "@material/mwc-textfield/mwc-textfield-base";
+import { styles } from "@material/mwc-textfield/mwc-textfield.css";
+import type { TemplateResult, PropertyValues } from "lit";
+import { html, css } from "lit";
+import { customElement, property, query } from "lit/decorators";
+import { mainWindow } from "../common/dom/get_main_window";
+
+@customElement("ha-textfield")
+export class HaTextField extends TextFieldBase {
+  @property({ type: Boolean }) public invalid?: boolean;
+
+  @property({ attribute: "error-message" }) public errorMessage?: string;
+
+  // @ts-ignore
+  @property({ type: Boolean }) public icon = false;
+
+  // @ts-ignore
+  @property({ type: Boolean }) public iconTrailing = false;
+
+  @property() public autocomplete?: string;
+
+  @property() public autocorrect?: string;
+
+  @property({ attribute: "input-spellcheck" })
+  public inputSpellcheck?: string;
+
+  @query("input") public formElement!: HTMLInputElement;
+
+  override updated(changedProperties: PropertyValues) {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has("invalid") ||
+      changedProperties.has("errorMessage")
+    ) {
+      this.setCustomValidity(
+        this.invalid
+          ? this.errorMessage || this.validationMessage || "Invalid"
+          : ""
+      );
+      if (
+        this.invalid ||
+        this.validateOnInitialRender ||
+        (changedProperties.has("invalid") &&
+          changedProperties.get("invalid") !== undefined)
+      ) {
+        // Only report validity if the field is invalid or the invalid state has changed from
+        // true to false to prevent setting empty required fields to invalid on first render
+        this.reportValidity();
+      }
+    }
+    if (changedProperties.has("autocomplete")) {
+      if (this.autocomplete) {
+        this.formElement.setAttribute("autocomplete", this.autocomplete);
+      } else {
+        this.formElement.removeAttribute("autocomplete");
+      }
+    }
+    if (changedProperties.has("autocorrect")) {
+      if (this.autocorrect) {
+        this.formElement.setAttribute("autocorrect", this.autocorrect);
+      } else {
+        this.formElement.removeAttribute("autocorrect");
+      }
+    }
+    if (changedProperties.has("inputSpellcheck")) {
+      if (this.inputSpellcheck) {
+        this.formElement.setAttribute("spellcheck", this.inputSpellcheck);
+      } else {
+        this.formElement.removeAttribute("spellcheck");
+      }
+    }
+  }
+
+  protected override renderIcon(
+    _icon: string,
+    isTrailingIcon = false
+  ): TemplateResult {
+    const type = isTrailingIcon ? "trailing" : "leading";
+
+    return html`
+      <span
+        class="mdc-text-field__icon mdc-text-field__icon--${type}"
+        tabindex=${isTrailingIcon ? 1 : -1}
+      >
+        <slot name="${type}Icon"></slot>
+      </span>
+    `;
+  }
+
+  static override styles = [
+    styles,
+    css`
+      .mdc-text-field__input {
+        width: var(--ha-textfield-input-width, 100%);
+      }
+      .mdc-text-field:not(.mdc-text-field--with-leading-icon) {
+        padding: var(--text-field-padding, 0px 16px);
+      }
+      .mdc-text-field__affix--suffix {
+        padding-left: var(--text-field-suffix-padding-left, 12px);
+        padding-right: var(--text-field-suffix-padding-right, 0px);
+        padding-inline-start: var(--text-field-suffix-padding-left, 12px);
+        padding-inline-end: var(--text-field-suffix-padding-right, 0px);
+        direction: ltr;
+      }
+      .mdc-text-field--with-leading-icon {
+        padding-inline-start: var(--text-field-suffix-padding-left, 0px);
+        padding-inline-end: var(--text-field-suffix-padding-right, 16px);
+        direction: var(--direction);
+      }
+
+      .mdc-text-field--with-leading-icon.mdc-text-field--with-trailing-icon {
+        padding-left: var(--text-field-suffix-padding-left, 0px);
+        padding-right: var(--text-field-suffix-padding-right, 0px);
+        padding-inline-start: var(--text-field-suffix-padding-left, 0px);
+        padding-inline-end: var(--text-field-suffix-padding-right, 0px);
+      }
+      .mdc-text-field:not(.mdc-text-field--disabled)
+        .mdc-text-field__affix--suffix {
+        color: var(--secondary-text-color);
+      }
+
+      .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon {
+        color: var(--secondary-text-color);
+      }
+
+      .mdc-text-field__icon--leading {
+        margin-inline-start: 16px;
+        margin-inline-end: 8px;
+        direction: var(--direction);
+      }
+
+      .mdc-text-field__icon--trailing {
+        padding: var(--textfield-icon-trailing-padding, 12px);
+      }
+
+      .mdc-floating-label:not(.mdc-floating-label--float-above) {
+        text-overflow: ellipsis;
+        width: inherit;
+        padding-right: 30px;
+        padding-inline-end: 30px;
+        padding-inline-start: initial;
+        box-sizing: border-box;
+        direction: var(--direction);
+      }
+
+      input {
+        text-align: var(--text-field-text-align, start);
+      }
+
+      /* Edge, hide reveal password icon */
+      ::-ms-reveal {
+        display: none;
+      }
+
+      /* Chrome, Safari, Edge, Opera */
+      :host([no-spinner]) input::-webkit-outer-spin-button,
+      :host([no-spinner]) input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      /* Firefox */
+      :host([no-spinner]) input[type="number"] {
+        -moz-appearance: textfield;
+      }
+
+      .mdc-text-field__ripple {
+        overflow: hidden;
+      }
+
+      .mdc-text-field {
+        overflow: var(--text-field-overflow);
+      }
+
+      .mdc-floating-label {
+        inset-inline-start: 16px !important;
+        inset-inline-end: initial !important;
+        transform-origin: var(--float-start);
+        direction: var(--direction);
+        text-align: var(--float-start);
+      }
+
+      .mdc-text-field--with-leading-icon.mdc-text-field--filled
+        .mdc-floating-label {
+        max-width: calc(
+          100% - 48px - var(--text-field-suffix-padding-left, 0px)
+        );
+        inset-inline-start: calc(
+          48px + var(--text-field-suffix-padding-left, 0px)
+        ) !important;
+        inset-inline-end: initial !important;
+        direction: var(--direction);
+      }
+
+      .mdc-text-field__input[type="number"] {
+        direction: var(--direction);
+      }
+      .mdc-text-field__affix--prefix {
+        padding-right: var(--text-field-prefix-padding-right, 2px);
+        padding-inline-end: var(--text-field-prefix-padding-right, 2px);
+        padding-inline-start: initial;
+      }
+
+      .mdc-text-field:not(.mdc-text-field--disabled)
+        .mdc-text-field__affix--prefix {
+        color: var(--mdc-text-field-label-ink-color);
+      }
+    `,
+    // safari workaround - must be explicit
+    mainWindow.document.dir === "rtl"
+      ? css`
+          .mdc-text-field--with-leading-icon,
+          .mdc-text-field__icon--leading,
+          .mdc-floating-label,
+          .mdc-text-field--with-leading-icon.mdc-text-field--filled
+            .mdc-floating-label,
+          .mdc-text-field__input[type="number"] {
+            direction: rtl;
+            --direction: rtl;
+          }
+        `
+      : css``,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ha-textfield": HaTextField;
+  }
+}

--- a/src/ha/data/input_select.ts
+++ b/src/ha/data/input_select.ts
@@ -1,0 +1,67 @@
+import type {
+  HassEntityAttributeBase,
+  HassEntityBase,
+} from "home-assistant-js-websocket";
+import type { HomeAssistant } from "../types";
+
+interface InputSelectEntityAttributes extends HassEntityAttributeBase {
+  options: string[];
+}
+
+export interface InputSelectEntity extends HassEntityBase {
+  attributes: InputSelectEntityAttributes;
+}
+
+export interface InputSelect {
+  id: string;
+  name: string;
+  options: string[];
+  icon?: string;
+  initial?: string;
+}
+
+export interface InputSelectMutableParams {
+  name: string;
+  icon: string;
+  initial: string;
+  options: string[];
+}
+
+export const setInputSelectOption = (
+  hass: HomeAssistant,
+  entity: string,
+  option: string
+) =>
+  hass.callService("input_select", "select_option", {
+    option,
+    entity_id: entity,
+  });
+
+export const fetchInputSelect = (hass: HomeAssistant) =>
+  hass.callWS<InputSelect[]>({ type: "input_select/list" });
+
+export const createInputSelect = (
+  hass: HomeAssistant,
+  values: InputSelectMutableParams
+) =>
+  hass.callWS<InputSelect>({
+    type: "input_select/create",
+    ...values,
+  });
+
+export const updateInputSelect = (
+  hass: HomeAssistant,
+  id: string,
+  updates: Partial<InputSelectMutableParams>
+) =>
+  hass.callWS<InputSelect>({
+    type: "input_select/update",
+    input_select_id: id,
+    ...updates,
+  });
+
+export const deleteInputSelect = (hass: HomeAssistant, id: string) =>
+  hass.callWS({
+    type: "input_select/delete",
+    input_select_id: id,
+  });

--- a/src/ha/data/integration.ts
+++ b/src/ha/data/integration.ts
@@ -25,11 +25,16 @@ export interface IntegrationManifest {
   loggers?: string[];
   quality_scale?: "gold" | "internal" | "platinum" | "silver";
   iot_class:
-    | "assumed_state"
-    | "cloud_polling"
-    | "cloud_push"
-    | "local_polling"
-    | "local_push";
+  | "assumed_state"
+  | "cloud_polling"
+  | "cloud_push"
+  | "local_polling"
+  | "local_push";
   single_config_entry?: boolean;
   version?: string;
 }
+
+export const domainToName = (
+  domain: string,
+  manifest?: IntegrationManifest
+) => manifest?.name || domain;

--- a/src/ha/data/lovelace.ts
+++ b/src/ha/data/lovelace.ts
@@ -1,0 +1,374 @@
+import {
+    Connection,
+    getCollection,
+    HassEventBase,
+    HassServiceTarget,
+  } from "home-assistant-js-websocket";
+  import { HASSDomEvent } from "../common/dom/fire_event";
+  import { Lovelace, LovelaceCard } from "../panels/lovelace/types";
+  import { HomeAssistant } from "../types";
+  
+  export interface LovelacePanelConfig {
+    mode: "yaml" | "storage";
+  }
+  
+  export interface LovelaceConfig {
+    title?: string;
+    strategy?: {
+      type: string;
+      options?: Record<string, unknown>;
+    };
+    views: LovelaceViewConfig[];
+    background?: string;
+  }
+  
+  export interface LegacyLovelaceConfig extends LovelaceConfig {
+    resources?: LovelaceResource[];
+  }
+  
+  export interface LovelaceResource {
+    id: string;
+    type: "css" | "js" | "module" | "html";
+    url: string;
+  }
+  
+  export interface LovelaceResourcesMutableParams {
+    res_type: LovelaceResource["type"];
+    url: string;
+  }
+  
+  export type LovelaceDashboard =
+    | LovelaceYamlDashboard
+    | LovelaceStorageDashboard;
+  
+  interface LovelaceGenericDashboard {
+    id: string;
+    url_path: string;
+    require_admin: boolean;
+    show_in_sidebar: boolean;
+    icon?: string;
+    title: string;
+  }
+  
+  export interface LovelaceYamlDashboard extends LovelaceGenericDashboard {
+    mode: "yaml";
+    filename: string;
+  }
+  
+  export interface LovelaceStorageDashboard extends LovelaceGenericDashboard {
+    mode: "storage";
+  }
+  
+  export interface LovelaceDashboardMutableParams {
+    require_admin: boolean;
+    show_in_sidebar: boolean;
+    icon?: string;
+    title: string;
+  }
+  
+  export interface LovelaceDashboardCreateParams
+    extends LovelaceDashboardMutableParams {
+    url_path: string;
+    mode: "storage";
+  }
+  
+  export interface LovelaceViewConfig {
+    index?: number;
+    title?: string;
+    type?: string;
+    strategy?: {
+      type: string;
+      options?: Record<string, unknown>;
+    };
+    cards?: LovelaceCardConfig[];
+    path?: string;
+    icon?: string;
+    theme?: string;
+    panel?: boolean;
+    background?: string;
+    visible?: boolean | ShowViewConfig[];
+  }
+  
+  export interface LovelaceViewElement extends HTMLElement {
+    hass?: HomeAssistant;
+    lovelace?: Lovelace;
+    narrow?: boolean;
+    index?: number;
+    cards?: Array<LovelaceCard>;
+    isStrategy: boolean;
+    setConfig(config: LovelaceViewConfig): void;
+  }
+  
+  export interface ShowViewConfig {
+    user?: string;
+  }
+  
+  export interface LovelaceBadgeConfig {
+    type?: string;
+    [key: string]: any;
+  }
+  
+  export interface LovelaceCardConfig {
+    index?: number;
+    view_index?: number;
+    view_layout?: any;
+    type: string;
+    [key: string]: any;
+  }
+  
+  export interface LovelaceLayoutOptions {
+    grid_columns?: number;
+    grid_rows?: number;
+  }
+  
+  export interface LovelaceGridOptions {
+    columns?: number;
+    rows?: number;
+    min_columns?: number;
+    max_columns?: number;
+    min_rows?: number;
+    max_rows?: number;
+  }
+  
+  export interface ToggleActionConfig extends BaseActionConfig {
+    action: "toggle";
+  }
+  
+  export interface CallServiceActionConfig extends BaseActionConfig {
+    action: "call-service" | "perform-action";
+    /** @deprecated "service" is kept for backwards compatibility. Replaced by "perform_action". */
+    service?: string;
+    perform_action: string;
+    target?: HassServiceTarget;
+    /** @deprecated "service_data" is kept for backwards compatibility. Replaced by "data". */
+    service_data?: Record<string, unknown>;
+    data?: Record<string, unknown>;
+  }
+  
+  export interface NavigateActionConfig extends BaseActionConfig {
+    action: "navigate";
+    navigation_path: string;
+  }
+  
+  export interface UrlActionConfig extends BaseActionConfig {
+    action: "url";
+    url_path: string;
+  }
+  
+  export interface MoreInfoActionConfig extends BaseActionConfig {
+    action: "more-info";
+  }
+  
+  export interface NoActionConfig extends BaseActionConfig {
+    action: "none";
+  }
+  
+  export interface CustomActionConfig extends BaseActionConfig {
+    action: "fire-dom-event";
+  }
+  
+  export interface AssistActionConfig extends BaseActionConfig {
+    action: "assist";
+    pipeline_id?: string;
+    start_listening?: boolean;
+  }
+  
+  export interface BaseActionConfig {
+    action: string;
+    confirmation?: ConfirmationRestrictionConfig;
+  }
+  
+  export interface ConfirmationRestrictionConfig {
+    text?: string;
+    exemptions?: RestrictionConfig[];
+  }
+  
+  export interface RestrictionConfig {
+    user: string;
+  }
+  
+  export type ActionConfig =
+    | ToggleActionConfig
+    | CallServiceActionConfig
+    | NavigateActionConfig
+    | UrlActionConfig
+    | MoreInfoActionConfig
+    | AssistActionConfig
+    | NoActionConfig
+    | CustomActionConfig;
+  
+  type LovelaceUpdatedEvent = HassEventBase & {
+    event_type: "lovelace_updated";
+    data: {
+      url_path: string | null;
+      mode: "yaml" | "storage";
+    };
+  };
+  
+  export const fetchResources = (conn: Connection): Promise<LovelaceResource[]> =>
+    conn.sendMessagePromise({
+      type: "lovelace/resources",
+    });
+  
+  export const createResource = (
+    hass: HomeAssistant,
+    values: LovelaceResourcesMutableParams
+  ) =>
+    hass.callWS<LovelaceResource>({
+      type: "lovelace/resources/create",
+      ...values,
+    });
+  
+  export const updateResource = (
+    hass: HomeAssistant,
+    id: string,
+    updates: Partial<LovelaceResourcesMutableParams>
+  ) =>
+    hass.callWS<LovelaceResource>({
+      type: "lovelace/resources/update",
+      resource_id: id,
+      ...updates,
+    });
+  
+  export const deleteResource = (hass: HomeAssistant, id: string) =>
+    hass.callWS({
+      type: "lovelace/resources/delete",
+      resource_id: id,
+    });
+  
+  export const fetchDashboards = (
+    hass: HomeAssistant
+  ): Promise<LovelaceDashboard[]> =>
+    hass.callWS({
+      type: "lovelace/dashboards/list",
+    });
+  
+  export const createDashboard = (
+    hass: HomeAssistant,
+    values: LovelaceDashboardCreateParams
+  ) =>
+    hass.callWS<LovelaceDashboard>({
+      type: "lovelace/dashboards/create",
+      ...values,
+    });
+  
+  export const updateDashboard = (
+    hass: HomeAssistant,
+    id: string,
+    updates: Partial<LovelaceDashboardMutableParams>
+  ) =>
+    hass.callWS<LovelaceDashboard>({
+      type: "lovelace/dashboards/update",
+      dashboard_id: id,
+      ...updates,
+    });
+  
+  export const deleteDashboard = (hass: HomeAssistant, id: string) =>
+    hass.callWS({
+      type: "lovelace/dashboards/delete",
+      dashboard_id: id,
+    });
+  
+  export const fetchConfig = (
+    conn: Connection,
+    urlPath: string | null,
+    force: boolean
+  ): Promise<LovelaceConfig> =>
+    conn.sendMessagePromise({
+      type: "lovelace/config",
+      url_path: urlPath,
+      force,
+    });
+  
+  export const saveConfig = (
+    hass: HomeAssistant,
+    urlPath: string | null,
+    config: LovelaceConfig
+  ): Promise<void> =>
+    hass.callWS({
+      type: "lovelace/config/save",
+      url_path: urlPath,
+      config,
+    });
+  
+  export const deleteConfig = (
+    hass: HomeAssistant,
+    urlPath: string | null
+  ): Promise<void> =>
+    hass.callWS({
+      type: "lovelace/config/delete",
+      url_path: urlPath,
+    });
+  
+  export const subscribeLovelaceUpdates = (
+    conn: Connection,
+    urlPath: string | null,
+    onChange: () => void
+  ) =>
+    conn.subscribeEvents<LovelaceUpdatedEvent>((ev) => {
+      if (ev.data.url_path === urlPath) {
+        onChange();
+      }
+    }, "lovelace_updated");
+  
+  export const getLovelaceCollection = (
+    conn: Connection,
+    urlPath: string | null = null
+  ) =>
+    getCollection(
+      conn,
+      `_lovelace_${urlPath ?? ""}`,
+      (conn2) => fetchConfig(conn2, urlPath, false),
+      (_conn, store) =>
+        subscribeLovelaceUpdates(conn, urlPath, () =>
+          fetchConfig(conn, urlPath, false).then((config) =>
+            store.setState(config, true)
+          )
+        )
+    );
+  
+  // Legacy functions to support cast for Home Assistion < 0.107
+  const fetchLegacyConfig = (
+    conn: Connection,
+    force: boolean
+  ): Promise<LovelaceConfig> =>
+    conn.sendMessagePromise({
+      type: "lovelace/config",
+      force,
+    });
+  
+  const subscribeLegacyLovelaceUpdates = (
+    conn: Connection,
+    onChange: () => void
+  ) => conn.subscribeEvents(onChange, "lovelace_updated");
+  
+  export const getLegacyLovelaceCollection = (conn: Connection) =>
+    getCollection(
+      conn,
+      "_lovelace",
+      (conn2) => fetchLegacyConfig(conn2, false),
+      (_conn, store) =>
+        subscribeLegacyLovelaceUpdates(conn, () =>
+          fetchLegacyConfig(conn, false).then((config) =>
+            store.setState(config, true)
+          )
+        )
+    );
+  
+  export interface WindowWithLovelaceProm extends Window {
+    llConfProm?: Promise<LovelaceConfig>;
+    llResProm?: Promise<LovelaceResource[]>;
+  }
+  
+  export interface ActionHandlerOptions {
+    hasHold?: boolean;
+    hasDoubleClick?: boolean;
+    disabled?: boolean;
+  }
+  
+  export interface ActionHandlerDetail {
+    action: "hold" | "tap" | "double_tap";
+  }
+  
+  export type ActionHandlerEvent = HASSDomEvent<ActionHandlerDetail>;
+  

--- a/src/ha/data/main_window.ts
+++ b/src/ha/data/main_window.ts
@@ -1,0 +1,1 @@
+export const MAIN_WINDOW_NAME = "ha-main-window";

--- a/src/ha/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-element-editor.ts
@@ -18,12 +18,12 @@
 // } from "../types";
 // import type { HuiFormEditor } from "./config-elements/hui-form-editor";
 // import { GUISupportError } from "./gui-support-error";
-// import type {
-//   EditDetailElementEvent,
-//   EditSubElementEvent,
-//   GUIModeChangedEvent,
-//   SubElementEditorConfig,
-// } from "./types";
+import type {
+  EditDetailElementEvent,
+  EditSubElementEvent,
+  // GUIModeChangedEvent,
+  // SubElementEditorConfig,
+} from "./types";
 
 export interface ConfigChangedEvent<T extends object = object> {
   config: T;
@@ -35,8 +35,8 @@ declare global {
   interface HASSDomEvents {
     "config-changed": ConfigChangedEvent;
     // "GUImode-changed": GUIModeChangedEvent;
-    // "edit-detail-element": EditDetailElementEvent;
-    // "edit-sub-element": EditSubElementEvent;
+    "edit-detail-element": EditDetailElementEvent;
+    "edit-sub-element": EditSubElementEvent;
   }
 }
 

--- a/src/ha/panels/lovelace/editor/hui-element-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-element-editor.ts
@@ -1,0 +1,445 @@
+// import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
+// import { css, html, LitElement, nothing } from "lit";
+// import { property, query, state } from "lit/decorators";
+// import { cache } from "lit/directives/cache";
+// import type { HASSDomEvent } from "../../../common/dom/fire_event";
+// import { fireEvent } from "../../../common/dom/fire_event";
+// import { handleStructError } from "../../../common/structs/handle-errors";
+// import { deepEqual } from "../../../common/util/deep-equal";
+// import "../../../components/ha-alert";
+// import "../../../components/ha-circular-progress";
+// import "../../../components/ha-yaml-editor";
+// import type { HaYamlEditor } from "../../../components/ha-yaml-editor";
+// import type { LovelaceConfig } from "../../../data/lovelace/config/types";
+// import type { HomeAssistant } from "../../../types";
+// import type {
+//   LovelaceConfigForm,
+//   LovelaceGenericElementEditor,
+// } from "../types";
+// import type { HuiFormEditor } from "./config-elements/hui-form-editor";
+// import { GUISupportError } from "./gui-support-error";
+// import type {
+//   EditDetailElementEvent,
+//   EditSubElementEvent,
+//   GUIModeChangedEvent,
+//   SubElementEditorConfig,
+// } from "./types";
+
+export interface ConfigChangedEvent<T extends object = object> {
+  config: T;
+  error?: string;
+  guiModeAvailable?: boolean;
+}
+
+declare global {
+  interface HASSDomEvents {
+    "config-changed": ConfigChangedEvent;
+    // "GUImode-changed": GUIModeChangedEvent;
+    // "edit-detail-element": EditDetailElementEvent;
+    // "edit-sub-element": EditSubElementEvent;
+  }
+}
+
+// export interface UIConfigChangedEvent<T extends object = object> extends Event {
+//   detail: {
+//     config: T;
+//   };
+// }
+
+// export abstract class HuiElementEditor<
+//   T extends object = object,
+//   C = any,
+// > extends LitElement {
+//   @property({ attribute: false }) public hass!: HomeAssistant;
+
+//   @property({ attribute: false }) public lovelace?: LovelaceConfig;
+
+//   @property({ attribute: false }) public context?: C;
+
+//   @state() private _config?: T;
+
+//   @state() private _configElement?: LovelaceGenericElementEditor;
+
+//   @state() private _subElementEditorConfig?: SubElementEditorConfig;
+
+//   @state() private _guiMode = true;
+
+//   // Error: Configuration broken - do not save
+//   @state() private _errors?: string[];
+
+//   // Warning: GUI editor can't handle configuration - ok to save
+//   @state() private _warnings?: string[];
+
+//   @state() private _guiSupported?: boolean;
+
+//   @state() private _loading = false;
+
+//   @query("ha-yaml-editor") _yamlEditor?: HaYamlEditor;
+
+//   public get value(): T | undefined {
+//     return this._config;
+//   }
+
+//   public set value(config: T | undefined) {
+//     if (this._config && deepEqual(config, this._config)) {
+//       return;
+//     }
+//     this._config = config;
+//     this._errors = undefined;
+//     this._setConfig();
+//   }
+
+//   private _setConfig(): void {
+//     if (!this._errors) {
+//       try {
+//         this._updateConfigElement();
+//       } catch (err: any) {
+//         this._errors = [err.message];
+//       }
+//     }
+
+//     this.updateComplete.then(() => {
+//       fireEvent(this, "config-changed", {
+//         config: this.value! as any,
+//         error: this._errors?.join(", "),
+//         guiModeAvailable: !(
+//           this.hasWarning ||
+//           this.hasError ||
+//           this._guiSupported === false
+//         ),
+//       });
+//     });
+//   }
+
+//   public get hasWarning(): boolean {
+//     return this._warnings !== undefined && this._warnings.length > 0;
+//   }
+
+//   public get hasError(): boolean {
+//     return this._errors !== undefined && this._errors.length > 0;
+//   }
+
+//   public get GUImode(): boolean {
+//     return this._guiMode;
+//   }
+
+//   public set GUImode(guiMode: boolean) {
+//     this._guiMode = guiMode;
+//     this.updateComplete.then(() => {
+//       fireEvent(this as HTMLElement, "GUImode-changed", {
+//         guiMode,
+//         guiModeAvailable: !(
+//           this.hasWarning ||
+//           this.hasError ||
+//           this._guiSupported === false
+//         ),
+//       });
+//     });
+//   }
+
+//   public toggleMode() {
+//     this.GUImode = !this.GUImode;
+//   }
+
+//   public focusYamlEditor() {
+//     if (this._configElement?.focusYamlEditor) {
+//       this._configElement.focusYamlEditor();
+//     }
+//     if (!this._yamlEditor) {
+//       return;
+//     }
+//     this._yamlEditor.focus();
+//   }
+
+//   protected async getConfigElement(): Promise<
+//     LovelaceGenericElementEditor | undefined
+//   > {
+//     return undefined;
+//   }
+
+//   protected async getConfigForm(): Promise<LovelaceConfigForm | undefined> {
+//     return undefined;
+//   }
+
+//   protected renderConfigElement(): TemplateResult {
+//     return html`${this._configElement}`;
+//   }
+
+//   private _renderSubElement() {
+//     return html`
+//       <hui-sub-element-editor
+//         .hass=${this.hass}
+//         .config=${this._subElementEditorConfig}
+//         @go-back=${this._goBack}
+//         @config-changed=${this._subElementChanged}
+//       >
+//       </hui-sub-element-editor>
+//     `;
+//   }
+
+//   private _subElementChanged(ev: CustomEvent): void {
+//     ev.stopPropagation();
+
+//     const value = ev.detail.config;
+
+//     this._subElementEditorConfig = {
+//       ...this._subElementEditorConfig!,
+//       elementConfig: value,
+//     };
+
+//     this._subElementEditorConfig.saveElementConfig?.(value);
+//   }
+
+//   private _goBack(ev): void {
+//     ev.stopPropagation();
+//     this._subElementEditorConfig = undefined;
+//   }
+
+//   private async _editSubElement(
+//     ev: HASSDomEvent<EditSubElementEvent>
+//   ): Promise<void> {
+//     ev.stopPropagation();
+
+//     await import("./hui-sub-element-editor");
+
+//     this._subElementEditorConfig = {
+//       type: ev.detail.type,
+//       elementConfig: ev.detail.config,
+//       context: ev.detail.context,
+//       saveElementConfig: ev.detail.saveConfig,
+//     };
+//   }
+
+//   protected render(): TemplateResult {
+//     return html`
+//       <div class="wrapper">
+//         ${this.GUImode
+//           ? html`
+//               <div class="gui-editor" @edit-sub-element=${this._editSubElement}>
+//                 ${this._loading
+//                   ? html`
+//                       <ha-circular-progress
+//                         indeterminate
+//                         class="center margin-bot"
+//                       ></ha-circular-progress>
+//                     `
+//                   : cache(
+//                       this._subElementEditorConfig
+//                         ? this._renderSubElement()
+//                         : this.renderConfigElement()
+//                     )}
+//               </div>
+//             `
+//           : html`
+//               <div class="yaml-editor">
+//                 <ha-yaml-editor
+//                   .defaultValue=${this._config}
+//                   autofocus
+//                   .hass=${this.hass}
+//                   @value-changed=${this._handleYAMLChanged}
+//                   @keydown=${this._ignoreKeydown}
+//                   dir="ltr"
+//                 ></ha-yaml-editor>
+//               </div>
+//             `}
+//         ${this._guiSupported === false && this._loading === false
+//           ? html`
+//               <ha-alert
+//                 alert-type="info"
+//                 .title=${this.hass.localize(
+//                   "ui.errors.config.visual_editor_not_supported"
+//                 )}
+//               >
+//                 ${this.hass.localize(
+//                   "ui.errors.config.visual_editor_not_supported_reason_type"
+//                 )}
+//                 <br />
+//                 ${this.hass.localize("ui.errors.config.edit_in_yaml_supported")}
+//               </ha-alert>
+//             `
+//           : nothing}
+//         ${this.hasError
+//           ? html`
+//               <ha-alert
+//                 alert-type="error"
+//                 .title=${this.hass.localize(
+//                   "ui.errors.config.configuration_error"
+//                 )}
+//               >
+//                 <ul>
+//                   ${this._errors!.map((error) => html`<li>${error}</li>`)}
+//                 </ul>
+//               </ha-alert>
+//             `
+//           : nothing}
+//         ${this.hasWarning
+//           ? html`
+//               <ha-alert
+//                 alert-type="warning"
+//                 .title=${this.hass.localize(
+//                   "ui.errors.config.visual_editor_not_supported"
+//                 )}
+//               >
+//                 <ul>
+//                   ${this._warnings!.map((warning) => html`<li>${warning}</li>`)}
+//                 </ul>
+//                 ${this.hass.localize("ui.errors.config.edit_in_yaml_supported")}
+//               </ha-alert>
+//             `
+//           : nothing}
+//       </div>
+//     `;
+//   }
+
+//   protected updated(changedProperties: PropertyValues) {
+//     super.updated(changedProperties);
+
+//     if (this._configElement && changedProperties.has("hass")) {
+//       this._configElement.hass = this.hass;
+//     }
+//     if (
+//       this._configElement &&
+//       "lovelace" in this._configElement &&
+//       changedProperties.has("lovelace")
+//     ) {
+//       this._configElement.lovelace = this.lovelace;
+//     }
+//     if (this._configElement && changedProperties.has("context")) {
+//       this._configElement.context = this.context;
+//     }
+//   }
+
+//   private _handleUIConfigChanged(ev: UIConfigChangedEvent<T>) {
+//     ev.stopPropagation();
+//     if (!this.GUImode) return;
+//     const config = ev.detail.config;
+//     Object.keys(config).forEach((key) => {
+//       if (config[key] === undefined) {
+//         delete config[key];
+//       }
+//     });
+//     this.value = config as unknown as T;
+//   }
+
+//   private _handleYAMLChanged(ev: CustomEvent) {
+//     ev.stopPropagation();
+//     const config = ev.detail.value;
+//     if (ev.detail.isValid) {
+//       this._config = config;
+//       this._errors = undefined;
+//       this._setConfig();
+//     }
+//   }
+
+//   protected async unloadConfigElement(): Promise<void> {
+//     this._configElement = undefined;
+//     this._guiSupported = undefined;
+//   }
+
+//   protected async loadConfigElement(): Promise<void> {
+//     if (this._configElement) return;
+
+//     let configElement = await this.getConfigElement();
+
+//     if (!configElement) {
+//       const form = await this.getConfigForm();
+//       if (form) {
+//         await import("./config-elements/hui-form-editor");
+//         configElement = document.createElement("hui-form-editor");
+//         const { schema, assertConfig, computeLabel, computeHelper } = form;
+//         (configElement as HuiFormEditor).schema = schema;
+//         if (computeLabel) {
+//           (configElement as HuiFormEditor).computeLabel = computeLabel;
+//         }
+//         if (computeHelper) {
+//           (configElement as HuiFormEditor).computeHelper = computeHelper;
+//         }
+//         if (assertConfig) {
+//           (configElement as HuiFormEditor).assertConfig = assertConfig;
+//         }
+//       }
+//     }
+
+//     if (configElement) {
+//       configElement.hass = this.hass;
+//       if ("lovelace" in configElement) {
+//         configElement.lovelace = this.lovelace;
+//       }
+//       configElement.context = this.context;
+//       configElement.addEventListener("config-changed", (ev) =>
+//         this._handleUIConfigChanged(ev as UIConfigChangedEvent<T>)
+//       );
+//       this._guiSupported = true;
+//     } else {
+//       this._guiSupported = false;
+//     }
+
+//     this._configElement = configElement;
+//   }
+
+//   private async _updateConfigElement(): Promise<void> {
+//     if (!this.value) {
+//       return;
+//     }
+
+//     try {
+//       this._errors = undefined;
+//       this._warnings = undefined;
+
+//       await this.loadConfigElement();
+
+//       if (this._configElement) {
+//         // Setup GUI editor and check that it can handle the current config
+//         try {
+//           this._configElement.setConfig(this.value);
+//         } catch (err: any) {
+//           const msgs = handleStructError(this.hass, err);
+//           throw new GUISupportError(
+//             "Config is not supported",
+//             msgs.warnings,
+//             msgs.errors
+//           );
+//         }
+//       } else {
+//         this._guiSupported = false;
+//         this.GUImode = false;
+//       }
+//     } catch (err: any) {
+//       if (err instanceof GUISupportError) {
+//         this._warnings = err.warnings ?? [err.message];
+//         this._errors = err.errors || undefined;
+//       } else {
+//         this._errors = [err.message];
+//       }
+//       this.GUImode = false;
+//     } finally {
+//       this._loading = false;
+//     }
+//   }
+
+//   private _ignoreKeydown(ev: KeyboardEvent) {
+//     ev.stopPropagation();
+//   }
+
+//   static get styles(): CSSResultGroup {
+//     return css`
+//       :host {
+//         display: flex;
+//       }
+//       .wrapper {
+//         width: 100%;
+//       }
+//       .gui-editor,
+//       .yaml-editor {
+//         padding: 8px 0px;
+//       }
+//       ha-code-editor {
+//         --code-mirror-max-height: calc(100vh - 245px);
+//       }
+//       ha-circular-progress {
+//         display: block;
+//         margin: auto;
+//       }
+//     `;
+//   }
+// }

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -44,7 +44,6 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     }
 
     return html`
-      <p>Placeholder entry to make this recognisable</p>
       <h3>
         ${this.label ||
       `${this.hass!.localize(

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -4,11 +4,7 @@ import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat";
 import { fireEvent } from "../../../common/dom/fire_event";
-// import "../../../components/entity/ha-entity-picker";
 import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
-// import "../../../components/ha-icon-button";
-// import "../../../components/ha-sortable";
-// import "../../../components/ha-svg-icon";
 import type { HomeAssistant } from "../../../types";
 import type { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
 
@@ -20,7 +16,7 @@ declare global {
   }
 }
 
-@customElement("hui-entities-card-row-editor")
+@customElement("elec-sankey-hui-entities-card-row-editor")
 export class HuiEntitiesCardRowEditor extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
 

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -111,6 +111,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
       </ha-sortable>
       <ha-entity-picker
         class="add-entity"
+        include-device-classes=${deviceClassesFilter}
         .hass=${this.hass}
         @value-changed=${this._addEntity}
       ></ha-entity-picker>

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -26,6 +26,8 @@ export class HuiEntitiesCardRowEditor extends LitElement {
 
   @property({ attribute: false }) public entities?: LovelaceRowConfig[];
 
+  @property() public includeDeviceClasses?: string[];
+
   @property() public label?: string;
 
   private _entityKeys = new WeakMap<LovelaceRowConfig, string>();
@@ -42,6 +44,9 @@ export class HuiEntitiesCardRowEditor extends LitElement {
     if (!this.entities || !this.hass) {
       return nothing;
     }
+    const deviceClassesFilter = this.includeDeviceClasses
+      ? '["' + this.includeDeviceClasses?.join('","') + '"]'
+      : "";
 
     return html`
       <h3>
@@ -82,6 +87,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
             : html`
                       <ha-entity-picker
                         allow-custom-entity
+                        include-device-classes=${deviceClassesFilter}
                         hideClearIcon
                         .hass=${this.hass}
                         .value=${(entityConf as EntityConfig).entity}

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -1,0 +1,250 @@
+import { mdiClose, mdiDrag, mdiPencil } from "@mdi/js";
+import type { CSSResultGroup } from "lit";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat";
+import { fireEvent } from "../../../common/dom/fire_event";
+// import "../../../components/entity/ha-entity-picker";
+import type { HaEntityPicker } from "../../../components/entity/ha-entity-picker";
+// import "../../../components/ha-icon-button";
+// import "../../../components/ha-sortable";
+// import "../../../components/ha-svg-icon";
+import type { HomeAssistant } from "../../../types";
+import type { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
+
+declare global {
+  interface HASSDomEvents {
+    "entities-changed": {
+      entities: LovelaceRowConfig[];
+    };
+  }
+}
+
+@customElement("hui-entities-card-row-editor")
+export class HuiEntitiesCardRowEditor extends LitElement {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @property({ attribute: false }) public entities?: LovelaceRowConfig[];
+
+  @property() public label?: string;
+
+  private _entityKeys = new WeakMap<LovelaceRowConfig, string>();
+
+  private _getKey(action: LovelaceRowConfig) {
+    if (!this._entityKeys.has(action)) {
+      this._entityKeys.set(action, Math.random().toString());
+    }
+
+    return this._entityKeys.get(action)!;
+  }
+
+  protected render() {
+    if (!this.entities || !this.hass) {
+      return nothing;
+    }
+
+    return html`
+      <p>Placeholder entry to make this recognisable</p>
+      <h3>
+        ${this.label ||
+      `${this.hass!.localize(
+        "ui.panel.lovelace.editor.card.generic.entities"
+      )} (${this.hass!.localize(
+        "ui.panel.lovelace.editor.card.config.required"
+      )})`}
+      </h3>
+      <ha-sortable handle-selector=".handle" @item-moved=${this._rowMoved}>
+        <div class="entities">
+          ${repeat(
+        this.entities,
+        (entityConf) => this._getKey(entityConf),
+        (entityConf, index) => html`
+              <div class="entity">
+                <div class="handle">
+                  <ha-svg-icon .path=${mdiDrag}></ha-svg-icon>
+                </div>
+                ${entityConf.type
+            ? html`
+                      <div class="special-row">
+                        <div>
+                          <span>
+                            ${this.hass!.localize(
+              `ui.panel.lovelace.editor.card.entities.entity_row.${entityConf.type}`
+            )}
+                          </span>
+                          <span class="secondary"
+                            >${this.hass!.localize(
+              "ui.panel.lovelace.editor.card.entities.edit_special_row"
+            )}</span
+                          >
+                        </div>
+                      </div>
+                    `
+            : html`
+                      <ha-entity-picker
+                        allow-custom-entity
+                        hideClearIcon
+                        .hass=${this.hass}
+                        .value=${(entityConf as EntityConfig).entity}
+                        .index=${index}
+                        @value-changed=${this._valueChanged}
+                      ></ha-entity-picker>
+                    `}
+                <ha-icon-button
+                  .label=${this.hass!.localize(
+              "ui.components.entity.entity-picker.clear"
+            )}
+                  .path=${mdiClose}
+                  class="remove-icon"
+                  .index=${index}
+                  @click=${this._removeRow}
+                ></ha-icon-button>
+                <ha-icon-button
+                  .label=${this.hass!.localize(
+              "ui.components.entity.entity-picker.edit"
+            )}
+                  .path=${mdiPencil}
+                  class="edit-icon"
+                  .index=${index}
+                  @click=${this._editRow}
+                ></ha-icon-button>
+              </div>
+            `
+      )}
+        </div>
+      </ha-sortable>
+      <ha-entity-picker
+        class="add-entity"
+        .hass=${this.hass}
+        @value-changed=${this._addEntity}
+      ></ha-entity-picker>
+    `;
+  }
+
+  private async _addEntity(ev: CustomEvent): Promise<void> {
+    const value = ev.detail.value;
+    if (value === "") {
+      return;
+    }
+    const newConfigEntities = this.entities!.concat({
+      entity: value as string,
+    });
+    (ev.target as HaEntityPicker).value = "";
+    fireEvent(this, "entities-changed", { entities: newConfigEntities });
+  }
+
+  private _rowMoved(ev: CustomEvent): void {
+    ev.stopPropagation();
+    const { oldIndex, newIndex } = ev.detail;
+
+    const newEntities = this.entities!.concat();
+
+    newEntities.splice(newIndex, 0, newEntities.splice(oldIndex, 1)[0]);
+
+    fireEvent(this, "entities-changed", { entities: newEntities });
+  }
+
+  private _removeRow(ev: CustomEvent): void {
+    const index = (ev.currentTarget as any).index;
+    const newConfigEntities = this.entities!.concat();
+
+    newConfigEntities.splice(index, 1);
+
+    fireEvent(this, "entities-changed", { entities: newConfigEntities });
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    const value = ev.detail.value;
+    const index = (ev.target as any).index;
+    const newConfigEntities = this.entities!.concat();
+
+    if (value === "" || value === undefined) {
+      newConfigEntities.splice(index, 1);
+    } else {
+      newConfigEntities[index] = {
+        ...newConfigEntities[index],
+        entity: value!,
+      };
+    }
+
+    fireEvent(this, "entities-changed", { entities: newConfigEntities });
+  }
+
+  private _editRow(ev: CustomEvent): void {
+    const index = (ev.currentTarget as any).index;
+    fireEvent(this, "edit-detail-element", {
+      subElementConfig: {
+        index,
+        type: "row",
+        elementConfig: this.entities![index],
+      },
+    });
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      ha-entity-picker {
+        margin-top: 8px;
+      }
+      .add-entity {
+        display: block;
+        margin-left: 31px;
+        margin-right: 71px;
+        margin-inline-start: 31px;
+        margin-inline-end: 71px;
+        direction: var(--direction);
+      }
+      .entity {
+        display: flex;
+        align-items: center;
+      }
+
+      .entity .handle {
+        padding-right: 8px;
+        cursor: move; /* fallback if grab cursor is unsupported */
+        cursor: grab;
+        padding-inline-end: 8px;
+        padding-inline-start: initial;
+        direction: var(--direction);
+      }
+      .entity .handle > * {
+        pointer-events: none;
+      }
+
+      .entity ha-entity-picker {
+        flex-grow: 1;
+      }
+
+      .special-row {
+        height: 60px;
+        font-size: 16px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-grow: 1;
+      }
+
+      .special-row div {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .remove-icon,
+      .edit-icon {
+        --mdc-icon-button-size: 36px;
+        color: var(--secondary-text-color);
+      }
+
+      .secondary {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "hui-entities-card-row-editor": HuiEntitiesCardRowEditor;
+  }
+}

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -98,15 +98,6 @@ export class HuiEntitiesCardRowEditor extends LitElement {
                   .index=${index}
                   @click=${this._removeRow}
                 ></ha-icon-button>
-                <ha-icon-button
-                  .label=${this.hass!.localize(
-              "ui.components.entity.entity-picker.edit"
-            )}
-                  .path=${mdiPencil}
-                  class="edit-icon"
-                  .index=${index}
-                  @click=${this._editRow}
-                ></ha-icon-button>
               </div>
             `
       )}

--- a/src/ha/panels/lovelace/editor/process-editor-entities.ts
+++ b/src/ha/panels/lovelace/editor/process-editor-entities.ts
@@ -1,0 +1,12 @@
+import type { EntityConfig } from "../entity-rows/types";
+
+export function processEditorEntities(
+  entities: (any | string)[]
+): EntityConfig[] {
+  return entities.map((entityConf) => {
+    if (typeof entityConf === "string") {
+      return { entity: entityConf };
+    }
+    return entityConf;
+  });
+}

--- a/src/ha/panels/lovelace/editor/types.ts
+++ b/src/ha/panels/lovelace/editor/types.ts
@@ -1,0 +1,115 @@
+import type { ActionConfig } from "../../../data/lovelace/config/action";
+import type { LovelaceCardConfig } from "../../../data/lovelace/config/card";
+// import type {
+//   LovelaceViewConfig,
+//   ShowViewConfig,
+// } from "../../../data/lovelace/config/view";
+import type { EntityConfig, LovelaceRowConfig } from "../entity-rows/types";
+// import type { LovelaceHeaderFooterConfig } from "../header-footer/types";
+// import type { LovelaceCardFeatureConfig } from "../card-features/types";
+import type { LovelaceElementConfig } from "../elements/types";
+// import type { LovelaceBadgeConfig } from "../../../data/lovelace/config/badge";
+// import type { LovelaceHeadingBadgeConfig } from "../heading-badges/types";
+
+// export interface YamlChangedEvent extends Event {
+//   detail: {
+//     yaml: string;
+//   };
+// }
+
+// export interface GUIModeChangedEvent {
+//   guiMode: boolean;
+//   guiModeAvailable: boolean;
+// }
+
+// export interface ViewEditEvent extends Event {
+//   detail: {
+//     config: LovelaceViewConfig;
+//   };
+// }
+
+// export interface ViewVisibilityChangeEvent {
+//   visible: ShowViewConfig[];
+// }
+
+// export interface ConfigValue {
+//   format: "json" | "yaml";
+//   value?: string | LovelaceCardConfig;
+// }
+
+// export interface ConfigError {
+//   type: string;
+//   message: string;
+// }
+
+// export interface EntitiesEditorEvent extends CustomEvent {
+//   detail: {
+//     entities?: EntityConfig[];
+//     item?: any;
+//   };
+//   target: EventTarget | null;
+// }
+
+// export interface EditorTarget extends EventTarget {
+//   value?: string;
+//   index?: number;
+//   checked?: boolean;
+//   configValue?: string;
+//   type?: HTMLInputElement["type"];
+//   config: ActionConfig;
+// }
+
+// export interface Card {
+//   type: string;
+//   name?: string;
+//   description?: string;
+//   showElement?: boolean;
+//   isCustom?: boolean;
+//   isSuggested?: boolean;
+// }
+
+// export interface Badge {
+//   type: string;
+//   name?: string;
+//   description?: string;
+//   showElement?: boolean;
+//   isCustom?: boolean;
+//   isSuggested?: boolean;
+// }
+
+// export interface HeaderFooter {
+//   type: LovelaceHeaderFooterConfig["type"];
+//   icon?: string;
+// }
+
+// export interface CardPickTarget extends EventTarget {
+//   config: LovelaceCardConfig;
+// }
+
+// export interface BadgePickTarget extends EventTarget {
+//   config: LovelaceBadgeConfig;
+// }
+
+export interface SubElementEditorConfig {
+  index?: number;
+  elementConfig?:
+  | LovelaceRowConfig
+  // | LovelaceHeaderFooterConfig
+  // | LovelaceCardFeatureConfig
+  | LovelaceElementConfig
+  // | LovelaceHeadingBadgeConfig;
+  saveElementConfig?: (elementConfig: any) => void;
+  context?: any;
+  type: "header" | "footer" | "row" | "feature" | "element" | "heading-badge";
+}
+
+export interface EditSubElementEvent<T = any, C = any> {
+  type: SubElementEditorConfig["type"];
+  context?: C;
+  config: T;
+  saveConfig: (config: T) => void;
+}
+
+export interface EditDetailElementEvent {
+  subElementConfig: SubElementEditorConfig;
+}

--- a/src/ha/panels/lovelace/editor/types.ts
+++ b/src/ha/panels/lovelace/editor/types.ts
@@ -50,14 +50,14 @@ import type { LovelaceElementConfig } from "../elements/types";
 //   target: EventTarget | null;
 // }
 
-// export interface EditorTarget extends EventTarget {
-//   value?: string;
-//   index?: number;
-//   checked?: boolean;
-//   configValue?: string;
-//   type?: HTMLInputElement["type"];
-//   config: ActionConfig;
-// }
+export interface EditorTarget extends EventTarget {
+  value?: string;
+  index?: number;
+  checked?: boolean;
+  configValue?: string;
+  type?: HTMLInputElement["type"];
+  config: ActionConfig;
+}
 
 // export interface Card {
 //   type: string;

--- a/src/ha/panels/lovelace/types.ts
+++ b/src/ha/panels/lovelace/types.ts
@@ -1,38 +1,31 @@
-// import { HassEntity } from "home-assistant-js-websocket";
-// import { LocalizeFunc } from "../../common/translations/localize";
-// import { HaFormSchema } from "../../components/ha-form/types";
-// import { LovelaceBadgeConfig } from "../../data/lovelace/config/badge";
-import { LovelaceCardConfig } from "../../data/lovelace/config/card";
-// import {
-//   LovelaceConfig,
-//   LovelaceRawConfig,
-// } from "../../data/lovelace/config/types";
-// import { FrontendLocaleData } from "../../data/translation";
+import {
+  LovelaceCardConfig,
+  LovelaceConfig,
+} from "../../data/lovelace";
+import { FrontendLocaleData } from "../../data/translation";
 import { Constructor, HomeAssistant } from "../../types";
-// import { LovelaceRow, LovelaceRowConfig } from "./entity-rows/types";
-// import { LovelaceHeaderFooterConfig } from "./header-footer/types";
-// import { LovelaceCardFeatureConfig } from "./card-features/types";
 
-// declare global {
-//   // eslint-disable-next-line
-//   interface HASSDomEvents {
-//     "ll-rebuild": Record<string, unknown>;
-//     "ll-badge-rebuild": Record<string, unknown>;
-//   }
-// }
+declare global {
+  // eslint-disable-next-line
+  interface HASSDomEvents {
+    "ll-rebuild": Record<string, unknown>;
+    "ll-badge-rebuild": Record<string, unknown>;
+  }
+}
 
-// export interface Lovelace {
-//   config: LovelaceConfig;
-//   rawConfig: LovelaceRawConfig;
-//   editMode: boolean;
-//   urlPath: string | null;
-//   mode: "generated" | "yaml" | "storage";
-//   locale: FrontendLocaleData;
-//   enableFullEditMode: () => void;
-//   setEditMode: (editMode: boolean) => void;
-//   saveConfig: (newConfig: LovelaceRawConfig) => Promise<void>;
-//   deleteConfig: () => Promise<void>;
-// }
+export interface Lovelace {
+  config: LovelaceConfig;
+  // If not set, a strategy was used to generate everything
+  rawConfig: LovelaceConfig | undefined;
+  editMode: boolean;
+  urlPath: string | null;
+  mode: "generated" | "yaml" | "storage";
+  locale: FrontendLocaleData;
+  enableFullEditMode: () => void;
+  setEditMode: (editMode: boolean) => void;
+  saveConfig: (newConfig: LovelaceConfig) => Promise<void>;
+  deleteConfig: () => Promise<void>;
+}
 
 // export interface LovelaceBadge extends HTMLElement {
 //   hass?: HomeAssistant;
@@ -73,7 +66,6 @@ export interface LovelaceCard extends HTMLElement {
 //     entitiesFallback: string[]
 //   ) => LovelaceCardConfig;
 //   getConfigElement?: () => LovelaceCardEditor;
-//   getConfigForm?: () => LovelaceConfigForm;
 // }
 
 // export interface LovelaceHeaderFooterConstructor
@@ -110,14 +102,20 @@ export interface LovelaceCard extends HTMLElement {
 //   setConfig(config: LovelaceRowConfig): void;
 // }
 
-// export interface LovelaceGenericElementEditor<C = any> extends HTMLElement {
-//   hass?: HomeAssistant;
-//   lovelace?: LovelaceConfig;
-//   context?: C;
-//   setConfig(config: any): void;
-//   focusYamlEditor?: () => void;
+export interface LovelaceCardEditor extends LovelaceGenericElementEditor {
+  setConfig(config: LovelaceCardConfig): void;
+}
+
+// export interface LovelaceBadgeEditor extends LovelaceGenericElementEditor {
+//   setConfig(config: LovelaceBadgeConfig): void;
 // }
 
+export interface LovelaceGenericElementEditor extends HTMLElement {
+  hass?: HomeAssistant;
+  lovelace?: LovelaceConfig;
+  setConfig(config: any): void;
+  focusYamlEditor?: () => void;
+}
 // export interface LovelaceCardFeature extends HTMLElement {
 //   hass?: HomeAssistant;
 //   stateObj?: HassEntity;

--- a/src/ha/resources/sortable.ts
+++ b/src/ha/resources/sortable.ts
@@ -1,0 +1,12 @@
+import type Sortable from "sortablejs";
+import SortableCore, {
+  AutoScroll,
+  OnSpill,
+} from "sortablejs/modular/sortable.core.esm";
+
+SortableCore.mount(OnSpill);
+SortableCore.mount(new AutoScroll());
+
+export default SortableCore as typeof Sortable;
+
+export type { Sortable as SortableInstance };

--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -20,10 +20,11 @@ import {
 } from "./ha/data/recorder";
 import { SubscribeMixin } from "./ha/mixins/subscribe-mixin";
 import { HomeAssistant } from "./ha/types";
-import { LovelaceCard } from "./ha/panels/lovelace/types";
+import type { LovelaceCard, LovelaceCardEditor } from "./ha/panels/lovelace/types";
 import { EnergyElecFlowCardConfig } from "./types";
 
 import { registerCustomCard } from "./utils/custom-cards";
+import { ENERGY_CARD_EDITOR_NAME } from "./const";
 
 registerCustomCard({
   type: "hui-energy-elec-flow-card",
@@ -60,6 +61,13 @@ export class HuiEnergyElecFlowCard
 
   public getCardSize(): Promise<number> | number {
     return 3;
+  }
+
+  public static async getConfigElement(): Promise<LovelaceCardEditor> {
+    await import("./energy-flow-card-editor");
+    return document.createElement(
+      ENERGY_CARD_EDITOR_NAME
+    ) as LovelaceCardEditor;
   }
 
   public setConfig(config: EnergyElecFlowCardConfig): void {

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -22,6 +22,7 @@ import { hasConfigChanged } from "./ha/panels/lovelace/common/has-changed";
 import { registerCustomCard } from "./utils/custom-cards";
 import { getEnergyPreferences } from "./ha/data/energy";
 import { ExtEntityRegistryEntry, getExtendedEntityRegistryEntry } from "./ha/data/entity_registry";
+//import "./power-flow-card-editor"
 
 
 import { POWER_CARD_NAME, POWER_CARD_EDITOR_NAME } from "./const";
@@ -43,7 +44,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
     await import("./power-flow-card-editor");
     return document.createElement(
       POWER_CARD_EDITOR_NAME
-    ) as LovelaceCardEditor
+    ) as LovelaceCardEditor;
   }
 
   public getCardSize(): number {

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -16,12 +16,15 @@ import { computeStateName } from "./ha/common/entity/compute_state_name";
 import { isValidEntityId } from "./ha/common/entity/valid_entity_id";
 import type { HomeAssistant } from "./ha/types";
 import { createEntityNotFoundWarning } from "./ha/panels/lovelace/components/hui-warning";
-import type { LovelaceCard } from "./ha/panels/lovelace/types";
+import type { LovelaceCard, LovelaceCardEditor } from "./ha/panels/lovelace/types";
 import type { PowerFlowCardConfig } from "./types";
 import { hasConfigChanged } from "./ha/panels/lovelace/common/has-changed";
 import { registerCustomCard } from "./utils/custom-cards";
 import { getEnergyPreferences } from "./ha/data/energy";
 import { ExtEntityRegistryEntry, getExtendedEntityRegistryEntry } from "./ha/data/entity_registry";
+
+
+import { POWER_CARD_NAME, POWER_CARD_EDITOR_NAME } from "./const";
 
 registerCustomCard({
   type: "hui-power-flow-card",
@@ -35,6 +38,13 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass!: HomeAssistant;
 
   @state() private _config?: PowerFlowCardConfig;
+
+  public static async getConfigElement(): Promise<LovelaceCardEditor> {
+    await import("./power-flow-card-editor");
+    return document.createElement(
+      POWER_CARD_EDITOR_NAME
+    ) as LovelaceCardEditor
+  }
 
   public getCardSize(): number {
     return 3;

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -28,6 +28,14 @@ const schema = [
       }
     }
   },
+  {
+    name: "generation_entity", selector: {
+      entity: {
+        domain: "sensor",
+        device_class: "power",
+      }
+    }
+  },
   { name: "group_small", selector: { boolean: {} } },
   // {
   //   type: "grid",
@@ -82,7 +90,14 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
   }
 
   private _computeLabel = (schema: HaFormSchema) => {
-    return `${schema.name} - placeholder label`;
+    switch (schema.name) {
+      case "title": return "Title";
+      case "power_from_grid_entity": return "Power from grid";
+      case "group_small": return "Group low values together";
+      case "generation_entity": return "Power from generation (optional)";
+    }
+    console.error("Error name key missing for '" + schema.name + "'")
+    return ""
   };
 
   protected render() {
@@ -151,6 +166,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         !== this._config.power_from_grid_entity) {
         configValue = "power_from_grid_entity";
         value = value.power_from_grid_entity;
+      }
+      else if (value.generation_entity
+        !== this._config.generation_entity) {
+        configValue = "generation_entity";
+        value = value.generation_entity;
       }
       else {
         console.warn("unhandled change in <ha-form>");

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -5,7 +5,7 @@ import { PowerFlowCardConfig } from "./types";
 import { html, LitElement, nothing } from "lit";
 import { HomeAssistant, LocalizeFunc } from "./ha/types";
 import { HaFormSchema } from "./utils/form/ha-form";
-//import "./ha/panels/lovelace/editor/hui-entities-card-row-editor";
+import "./ha/panels/lovelace/editor/hui-entities-card-row-editor";
 import memoizeOne from "memoize-one";
 import { fireEvent, HASSDomEvent } from "./ha/common/dom/fire_event";
 import type {
@@ -14,6 +14,7 @@ import type {
 } from "./ha/panels/lovelace/editor/types";
 
 import { POWER_CARD_EDITOR_NAME } from "./const";
+import { EntityConfig, LovelaceRowConfig } from "./ha/panels/lovelace/entity-rows/types";
 
 const schema = [
   { name: "title", selector: { text: {} } },
@@ -61,14 +62,18 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
 
   @state() private _config?: PowerFlowCardConfig;
 
-  @state() private _configEntities?: string[];
+  @state() private _configConsumerEntities: EntityConfig[] = []
 
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: PowerFlowCardConfig): void {
     this._config = config;
-    this._configEntities = config.consumer_entities;
-    this._configEntities?.forEach(element => {
+    config.consumer_entities?.forEach(element => {
+      const entityConfig: EntityConfig = {
+        entity: element,
+        name: "placeholder name1"
+      }
+      this._configConsumerEntities.push(entityConfig);
       console.log("element: ", element);
     });
   }
@@ -93,7 +98,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
       ></ha-form>
       <hui-entities-card-row-editor
         .hass=${this.hass}
-        .entities=${this._configEntities}
+        .entities=${this._configConsumerEntities}
         @entities-changed=${this._valueChanged}
         @edit-detail-element=${this._editDetailElement}
       ></hui-entities-card-row-editor>

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -9,12 +9,14 @@ import "./ha/panels/lovelace/editor/hui-entities-card-row-editor";
 import memoizeOne from "memoize-one";
 import { fireEvent, HASSDomEvent } from "./ha/common/dom/fire_event";
 import type {
+  EditorTarget,
   EditDetailElementEvent,
   SubElementEditorConfig,
 } from "./ha/panels/lovelace/editor/types";
 
 import { POWER_CARD_EDITOR_NAME } from "./const";
 import { EntityConfig, LovelaceRowConfig } from "./ha/panels/lovelace/entity-rows/types";
+import { processEditorEntities } from "./ha/panels/lovelace/editor/process-editor-entities";
 
 const schema = [
   { name: "title", selector: { text: {} } },
@@ -62,20 +64,25 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
 
   @state() private _config?: PowerFlowCardConfig;
 
+  @state() private _title?: string;
+
+  @state() private _theme?: string;
+
   @state() private _configConsumerEntities: EntityConfig[] = []
 
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: PowerFlowCardConfig): void {
     this._config = config;
-    config.consumer_entities?.forEach(element => {
-      const entityConfig: EntityConfig = {
-        entity: element,
-        name: "placeholder name1"
-      }
-      this._configConsumerEntities.push(entityConfig);
-      console.log("element: ", element);
-    });
+    // config.consumer_entities?.forEach(element => {
+    //   const entityConfig: EntityConfig = {
+    //     entity: element,
+    //     name: "placeholder name1"
+    //   }
+    //   this._configConsumerEntities.push(entityConfig);
+    //   console.log("element: ", element);
+    // });
+    this._configConsumerEntities = processEditorEntities(config.consumer_entities);
   }
 
   private _computeLabel = (schema: HaFormSchema) => {
@@ -83,8 +90,20 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
   };
 
   protected render() {
+    console.log("####Render####");
     if (!this.hass || !this._config) {
       return nothing;
+    }
+    if (this._subElementEditorConfig) {
+      return html`
+        <hui-sub-element-editor
+          .hass=${this.hass}
+          .config=${this._subElementEditorConfig}
+          @go-back=${this._goBack}
+          @config-changed=${this._handleSubElementChanged}
+        >
+        </hui-sub-element-editor>
+      `;
     }
 
     const data = { ...this._config } as any;
@@ -106,16 +125,109 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
   }
 
   private _valueChanged(ev: CustomEvent): void {
-    const config = { ...ev.detail.value };
-
-    if (config.display_mode === "default") {
-      delete config.display_mode;
+    ev.stopPropagation();
+    if (!this._config || !this.hass) {
+      return;
     }
 
-    fireEvent(this, "config-changed", { config });
+    const target = ev.target! as EditorTarget;
+    let configValue =
+      target.configValue || this._subElementEditorConfig?.type;
+    let value =
+      target.checked !== undefined
+        ? target.checked
+        : target.value || ev.detail.config || ev.detail.value;
+
+    if (!configValue && value) {
+      // A form value changed. We don't know which one.
+      // Could be title or anything else in the schema.
+      if (value.title !== this._title) {
+        configValue = "title";
+        value = value.title;
+      }
+      else if (value.theme !== this._theme) {
+        configValue = "theme";
+        value = value.theme;
+      }
+      console.warn("unhandled change in <ha-form>");
+    }
+
+    if (configValue === "row" || (ev.detail && ev.detail.entities)) {
+      const newConfigEntities =
+        ev.detail.entities || this._configConsumerEntities!.concat();
+      if (configValue === "row") {
+        if (!value) {
+          newConfigEntities.splice(this._subElementEditorConfig!.index!, 1);
+          this._goBack();
+        } else {
+          newConfigEntities[this._subElementEditorConfig!.index!] = value;
+        }
+
+        this._subElementEditorConfig!.elementConfig = value;
+      }
+
+      this._config = { ...this._config!, consumer_entities: newConfigEntities };
+      this._configConsumerEntities = processEditorEntities(this._config!.consumer_entities);
+    } else if (configValue) {
+      if (value === "") {
+        this._config = { ...this._config };
+        delete this._config[configValue!];
+      } else {
+        this._config = {
+          ...this._config,
+          [configValue]: value,
+        };
+      }
+    }
+    fireEvent(this, "config-changed", { config: this._config });
+  }
+
+  private _handleSubElementChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const configValue = this._subElementEditorConfig?.type;
+    const value = ev.detail.config;
+
+    if (configValue === "row") {
+      const newConfigEntities = this._configConsumerEntities!.concat();
+      if (!value) {
+        newConfigEntities.splice(this._subElementEditorConfig!.index!, 1);
+        this._goBack();
+      } else {
+        newConfigEntities[this._subElementEditorConfig!.index!] = value;
+      }
+
+      this._config = { ...this._config!, entities: newConfigEntities };
+      this._configConsumerEntities = processEditorEntities(this._config!.entities);
+    } else if (configValue) {
+      if (value === "") {
+        this._config = { ...this._config };
+        delete this._config[configValue!];
+      } else {
+        this._config = {
+          ...this._config,
+          [configValue]: value,
+        };
+      }
+    }
+
+    this._subElementEditorConfig = {
+      ...this._subElementEditorConfig!,
+      elementConfig: value,
+    };
+
+    fireEvent(this, "config-changed", { config: this._config });
   }
 
   private _editDetailElement(ev: HASSDomEvent<EditDetailElementEvent>): void {
     this._subElementEditorConfig = ev.detail.subElementConfig;
   }
+
+  private _goBack(): void {
+    this._subElementEditorConfig = undefined;
+  }
+
 }

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -1,0 +1,87 @@
+import { customElement, property, state } from "lit/decorators.js";
+
+import { LovelaceCardEditor } from "./ha/panels/lovelace/types";
+import { PowerFlowCardConfig } from "./types";
+import { html, LitElement, nothing } from "lit";
+import { HomeAssistant, LocalizeFunc } from "./ha/types";
+import { HaFormSchema } from "./utils/form/ha-form";
+import memoizeOne from "memoize-one";
+import { fireEvent } from "./ha/common/dom/fire_event";
+// import "ha/panels/lovelace/editor/hui-element-editor"
+import { POWER_CARD_EDITOR_NAME } from "./const";
+
+const GRID_POWER_IN_ENTITY_DOMAINS = ["sensor"];
+
+const schema = [
+  { name: "grid-in", selector: { entity: { domain: GRID_POWER_IN_ENTITY_DOMAINS } } },
+  { name: "name", selector: { text: {} } },
+  // {
+  //   type: "grid",
+  //   name: "",
+  //   schema: [
+  //     {
+  //       name: "icon",
+  //       selector: { icon: {} },
+  //       context: { icon_entity: "entity" },
+  //     },
+  //     { name: "icon_color", selector: { mush_color: {} } },
+  //   ],
+  // },
+  // ...APPEARANCE_FORM_SCHEMA,
+  // {
+  //   name: "display_mode",
+  //   selector: {
+  //     select: {
+  //       options: ["default", ...DISPLAY_MODES].map((control) => ({
+  //         value: control,
+  //         label: localize(`editor.card.number.display_mode_list.${control}`),
+  //       })),
+  //       mode: "dropdown",
+  //     },
+  //   },
+  // },
+  // ...computeActionsFormSchema(),
+];
+
+@customElement(POWER_CARD_EDITOR_NAME)
+export class PowerFlowCardEditor extends LitElement implements LovelaceCardEditor {
+
+  @property({ attribute: false }) public hass!: HomeAssistant;
+  
+  @state() private _config?: PowerFlowCardConfig;
+
+  public setConfig(config: PowerFlowCardConfig): void {
+    this._config = config;
+  }
+
+  private _computeLabel = (schema: HaFormSchema) => {
+    return `${schema.name} - placeholder label`;
+  };
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const data = { ...this._config } as any;
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${schema}
+        .computeLabel=${this._computeLabel}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;    
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    const config = { ...ev.detail.value };
+
+    if (config.display_mode === "default") {
+      delete config.display_mode;
+    }
+
+    fireEvent(this, "config-changed", { config });
+  }  
+}

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -113,7 +113,9 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
       ></ha-form>
       <hui-entities-card-row-editor
         .hass=${this.hass}
+        label="Consumer Entities (required)"
         .entities=${this._configConsumerEntities}
+        includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}
         @edit-detail-element=${this._editDetailElement}
       ></hui-entities-card-row-editor>

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -36,7 +36,7 @@ const schema = [
       }
     }
   },
-  { name: "group_small", selector: { boolean: {} } },
+  // { name: "group_small", selector: { boolean: {} } },
   // {
   //   type: "grid",
   //   name: "",

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -64,10 +64,6 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
 
   @state() private _config?: PowerFlowCardConfig;
 
-  @state() private _title?: string;
-
-  @state() private _theme?: string;
-
   @state() private _configConsumerEntities: EntityConfig[] = []
 
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
@@ -141,15 +137,22 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
     if (!configValue && value) {
       // A form value changed. We don't know which one.
       // Could be title or anything else in the schema.
-      if (value.title !== this._title) {
+      if (value.title !== this._config.title) {
         configValue = "title";
         value = value.title;
       }
-      else if (value.theme !== this._theme) {
-        configValue = "theme";
-        value = value.theme;
+      // else if (value.theme !== this._config.theme) {
+      //   configValue = "theme";
+      //   value = value.theme;
+      // }
+      else if (value.power_from_grid_entity
+        !== this._config.power_from_grid_entity) {
+        configValue = "power_from_grid_entity";
+        value = value.power_from_grid_entity;
       }
-      console.warn("unhandled change in <ha-form>");
+      else {
+        console.warn("unhandled change in <ha-form>");
+      }
     }
 
     if (configValue === "row" || (ev.detail && ev.detail.entities)) {

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -126,14 +126,14 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         .computeLabel=${this._computeLabel}
         @value-changed=${this._valueChanged}
       ></ha-form>
-      <hui-entities-card-row-editor
+      <elec-sankey-hui-entities-card-row-editor
         .hass=${this.hass}
         label="Consumer Entities (required)"
         .entities=${this._configConsumerEntities}
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}
         @edit-detail-element=${this._editDetailElement}
-      ></hui-entities-card-row-editor>
+      ></elec-sankey-hui-entities-card-row-editor>
     `;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,9 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   power_from_grid_entity?: string;
   power_to_grid_entity?: string;
   generation_entities?: string[];
-  consumer_entities?: string[];
+  consumer_entities: {
+    entity: string;
+    name?: string;
+  }[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   title?: string;
   power_from_grid_entity?: string;
   power_to_grid_entity?: string;
-  generation_entities?: string[];
+  generation_entity?: string;
   consumer_entities: {
     entity: string;
     name?: string;

--- a/src/utils/form/ha-form.ts
+++ b/src/utils/form/ha-form.ts
@@ -1,0 +1,112 @@
+import type { LitElement } from "lit";
+import { Selector } from "./ha-selector";
+
+interface HaDurationData {
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+  milliseconds?: number;
+}
+
+export type HaFormSchema =
+  | HaFormConstantSchema
+  | HaFormStringSchema
+  | HaFormIntegerSchema
+  | HaFormFloatSchema
+  | HaFormBooleanSchema
+  | HaFormSelectSchema
+  | HaFormMultiSelectSchema
+  | HaFormTimeSchema
+  | HaFormSelector
+  | HaFormGridSchema;
+
+export interface HaFormBaseSchema {
+  name: string;
+  // This value is applied if no data is submitted for this field
+  default?: HaFormData;
+  required?: boolean;
+  description?: {
+    suffix?: string;
+    // This value will be set initially when form is loaded
+    suggested_value?: HaFormData;
+  };
+  context?: Record<string, string>;
+}
+
+export interface HaFormGridSchema extends HaFormBaseSchema {
+  type: "grid";
+  name: "";
+  column_min_width?: string;
+  schema: HaFormSchema[];
+}
+
+export interface HaFormSelector extends HaFormBaseSchema {
+  type?: never;
+  selector: Selector;
+}
+
+export interface HaFormConstantSchema extends HaFormBaseSchema {
+  type: "constant";
+  value?: string;
+}
+
+export interface HaFormIntegerSchema extends HaFormBaseSchema {
+  type: "integer";
+  default?: HaFormIntegerData;
+  valueMin?: number;
+  valueMax?: number;
+}
+
+export interface HaFormSelectSchema extends HaFormBaseSchema {
+  type: "select";
+  options: Array<[string, string]>;
+}
+
+export interface HaFormMultiSelectSchema extends HaFormBaseSchema {
+  type: "multi_select";
+  options: Record<string, string> | string[] | Array<[string, string]>;
+}
+
+export interface HaFormFloatSchema extends HaFormBaseSchema {
+  type: "float";
+}
+
+export interface HaFormStringSchema extends HaFormBaseSchema {
+  type: "string";
+  format?: string;
+}
+
+export interface HaFormBooleanSchema extends HaFormBaseSchema {
+  type: "boolean";
+}
+
+export interface HaFormTimeSchema extends HaFormBaseSchema {
+  type: "positive_time_period_dict";
+}
+
+export interface HaFormDataContainer {
+  [key: string]: HaFormData;
+}
+
+export type HaFormData =
+  | HaFormStringData
+  | HaFormIntegerData
+  | HaFormFloatData
+  | HaFormBooleanData
+  | HaFormSelectData
+  | HaFormMultiSelectData
+  | HaFormTimeData;
+
+export type HaFormStringData = string;
+export type HaFormIntegerData = number;
+export type HaFormFloatData = number;
+export type HaFormBooleanData = boolean;
+export type HaFormSelectData = string;
+export type HaFormMultiSelectData = string[];
+export type HaFormTimeData = HaDurationData;
+
+export interface HaFormElement extends LitElement {
+  schema: HaFormSchema | HaFormSchema[];
+  data?: HaFormDataContainer | HaFormData;
+  label?: string;
+}

--- a/src/utils/form/ha-selector.ts
+++ b/src/utils/form/ha-selector.ts
@@ -1,0 +1,239 @@
+// This file is based on mushroom's src/utils/form/ha-selector.ts
+
+export type Selector =
+  | ActionSelector
+  | AddonSelector
+  | AreaSelector
+  | AttributeSelector
+  | BooleanSelector
+  | ColorRGBSelector
+  | ColorTempSelector
+  | DateSelector
+  | DateTimeSelector
+  | DeviceSelector
+  | DurationSelector
+  | EntitySelector
+  | IconSelector
+  | LocationSelector
+  | MediaSelector
+  | NumberSelector
+  | ObjectSelector
+  | SelectSelector
+  | StringSelector
+  | TargetSelector
+  | TemplateSelector
+  | ThemeSelector
+  | TimeSelector;
+
+export interface ActionSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  action: {};
+}
+
+export interface AddonSelector {
+  addon: {
+    name?: string;
+    slug?: string;
+  };
+}
+
+export interface AreaSelector {
+  area: {
+    entity?: {
+      integration?: EntitySelector["entity"]["integration"];
+      domain?: EntitySelector["entity"]["domain"];
+      device_class?: EntitySelector["entity"]["device_class"];
+    };
+    device?: {
+      integration?: DeviceSelector["device"]["integration"];
+      manufacturer?: DeviceSelector["device"]["manufacturer"];
+      model?: DeviceSelector["device"]["model"];
+    };
+    multiple?: boolean;
+  };
+}
+
+export interface AttributeSelector {
+  attribute: {
+    entity_id?: string;
+  };
+}
+
+export interface BooleanSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  boolean: {};
+}
+
+export interface ColorRGBSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  color_rgb: {};
+}
+
+export interface ColorTempSelector {
+  color_temp: {
+    min_mireds?: number;
+    max_mireds?: number;
+  };
+}
+
+export interface DateSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  date: {};
+}
+
+export interface DateTimeSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  datetime: {};
+}
+
+export interface DeviceSelector {
+  device: {
+    integration?: string;
+    manufacturer?: string;
+    model?: string;
+    entity?: {
+      domain?: EntitySelector["entity"]["domain"];
+      device_class?: EntitySelector["entity"]["device_class"];
+    };
+    multiple?: boolean;
+  };
+}
+
+export interface DurationSelector {
+  duration: {
+    enable_day?: boolean;
+  };
+}
+
+export interface EntitySelector {
+  entity: {
+    integration?: string;
+    domain?: string | string[];
+    device_class?: string;
+    multiple?: boolean;
+    include_entities?: string[];
+    exclude_entities?: string[];
+  };
+}
+
+export interface IconSelector {
+  icon: {
+    placeholder?: string;
+    fallbackPath?: string;
+  };
+}
+
+export interface LocationSelector {
+  location: { radius?: boolean; icon?: string };
+}
+
+export interface LocationSelectorValue {
+  latitude: number;
+  longitude: number;
+  radius?: number;
+}
+
+export interface MediaSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  media: {};
+}
+
+export interface MediaSelectorValue {
+  entity_id?: string;
+  media_content_id?: string;
+  media_content_type?: string;
+  metadata?: {
+    title?: string;
+    thumbnail?: string | null;
+    media_class?: string;
+    children_media_class?: string | null;
+    navigateIds?: { media_content_type: string; media_content_id: string }[];
+  };
+}
+
+export interface NumberSelector {
+  number: {
+    min?: number;
+    max?: number;
+    step?: number;
+    mode?: "box" | "slider";
+    unit_of_measurement?: string;
+  };
+}
+
+export interface ObjectSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  object: {};
+}
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SelectSelector {
+  select: {
+    multiple?: boolean;
+    custom_value?: boolean;
+    mode?: "list" | "dropdown";
+    options: string[] | SelectOption[];
+  };
+}
+
+export interface StringSelector {
+  text: {
+    multiline?: boolean;
+    type?:
+      | "number"
+      | "text"
+      | "search"
+      | "tel"
+      | "url"
+      | "email"
+      | "password"
+      | "date"
+      | "month"
+      | "week"
+      | "time"
+      | "datetime-local"
+      | "color";
+    suffix?: string;
+  };
+}
+
+export interface TargetSelector {
+  target: {
+    entity?: {
+      integration?: EntitySelector["entity"]["integration"];
+      domain?: EntitySelector["entity"]["domain"];
+      device_class?: EntitySelector["entity"]["device_class"];
+    };
+    device?: {
+      integration?: DeviceSelector["device"]["integration"];
+      manufacturer?: DeviceSelector["device"]["manufacturer"];
+      model?: DeviceSelector["device"]["model"];
+    };
+  };
+}
+
+export interface TemplateSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  template: {};
+}
+
+export interface ThemeSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  theme: {};
+}
+export interface TimeSelector {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  time: {};
+}
+
+// export type UiAction = Exclude<ActionConfig["action"], "fire-dom-event">;
+
+// export interface UiActionSelector {
+//   ui_action: {
+//     actions?: UiAction[];
+//   } | null;
+// }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,11 @@
         "target": "es2017",
         "module": "esnext",
         "moduleResolution": "node",
-        "lib": ["es2017", "dom", "dom.iterable"],
+        "lib": [
+            "es2017",
+            "dom",
+            "dom.iterable"
+        ],
         "noEmit": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,
@@ -17,6 +21,10 @@
         "outDir": "dist",
         "rootDir": "."
     },
-    "include": ["**/*.ts"],
-    "exclude": ["node_modules"]
+    "include": [
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
Adds graphical card editors for both power and energy cards.

Note that the energy card mirrors the HA energy dashboard config, so the only adjustable item so far is the title.

Existing configuration will not be compatible for power cards, it will be necessary to reconfigure (via the UI or yaml editor).
