### PR TITLE
Fix Issue17: GUI options to group smallest consumers

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -4,3 +4,12 @@ export const POWER_CARD_NAME = `${PREFIX_NAME}-power-flow-card`;
 export const POWER_CARD_EDITOR_NAME = `${POWER_CARD_NAME}-editor`;
 export const ENERGY_CARD_NAME = `${PREFIX_NAME}-energy-elec-flow-card`;
 export const ENERGY_CARD_EDITOR_NAME = `${ENERGY_CARD_NAME}-editor`;
+
+export const HIDE_CONSUMERS_BELOW_THRESHOLD_W = 100;
+export const HIDE_CONSUMERS_BELOW_THRESHOLD_WH = 100;
+
+export const GENERIC_LABELS = [
+    "appearance",
+    "title",
+    "max_consumer_branches",
+];

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -906,30 +906,12 @@ export class ElecSankey extends LitElement {
     return [divRet, svgRet, bottomLeftY, bottomRightY];
   }
 
-  protected _renderConsumerFlows(
-    y6: number,
-    y7: number,
-    color: string,
-    svgScaleX: number
-  ): [Array<TemplateResult>, Array<TemplateResult>, number] {
-    const divRetArray: Array<TemplateResult> = [];
-    const svgRetArray: Array<TemplateResult> = [];
-    const xLeft = 0;
-    const xRight = 100 - ARROW_HEAD_LENGTH;
-    let i = 0;
-    const total_height = this._consumersFanOutTotalHeight();
-    let yLeft = y6;
-    let yRight = (y6 + y7) / 2 - total_height / 2;
-    if (yRight < TEXT_PADDING) {
-      yRight = TEXT_PADDING;
-    }
-    let svgRow: TemplateResult;
-    let divRow: TemplateResult;
+  private _getGroupedConsumerRoutes(): { [id: string]: ElecRoute } {
     let consumerRoutes: { [id: string]: ElecRoute } = {};
     consumerRoutes = structuredClone(this.consumerRoutes);
     if (this.maxConsumerBranches !== 0) {
       const numConsumerRoutes = Object.keys(consumerRoutes).length;
-      if (numConsumerRoutes > this.maxConsumerBranches - 2) {
+      if (numConsumerRoutes > this.maxConsumerBranches - 1) {
 
         let otherCount = numConsumerRoutes + 2 - this.maxConsumerBranches;
         consumerRoutes = this.consumerRoutes;
@@ -952,6 +934,30 @@ export class ElecSankey extends LitElement {
         consumerRoutes[groupedConsumer.id!] = groupedConsumer;
       }
     }
+    return consumerRoutes;
+  }
+
+  protected _renderConsumerFlows(
+    y6: number,
+    y7: number,
+    color: string,
+    svgScaleX: number
+  ): [Array<TemplateResult>, Array<TemplateResult>, number] {
+    const divRetArray: Array<TemplateResult> = [];
+    const svgRetArray: Array<TemplateResult> = [];
+    const xLeft = 0;
+    const xRight = 100 - ARROW_HEAD_LENGTH;
+    let i = 0;
+    const total_height = this._consumersFanOutTotalHeight();
+    let yLeft = y6;
+    let yRight = (y6 + y7) / 2 - total_height / 2;
+    if (yRight < TEXT_PADDING) {
+      yRight = TEXT_PADDING;
+    }
+    let svgRow: TemplateResult;
+    let divRow: TemplateResult;
+
+    const consumerRoutes = this._getGroupedConsumerRoutes();
 
     for (const key in consumerRoutes) {
       if (Object.prototype.hasOwnProperty.call(consumerRoutes, key)) {

--- a/src/energy-flow-card-editor.ts
+++ b/src/energy-flow-card-editor.ts
@@ -8,10 +8,38 @@ import { HaFormSchema } from "./utils/form/ha-form";
 import "./ha/panels/lovelace/editor/hui-entities-card-row-editor";
 import { fireEvent } from "./ha/common/dom/fire_event";
 
-import { ENERGY_CARD_EDITOR_NAME } from "./const";
+import { ENERGY_CARD_EDITOR_NAME, GENERIC_LABELS } from "./const";
+import { mdiPalette } from "@mdi/js";
+import setupCustomlocalize from "./localize";
 
+const ENERGY_LABELS = [
+  "hide_small_consumers",
+]
 const schema = [
   { name: "title", selector: { text: {} } },
+
+  {
+    name: "appearance",
+    flatten: true,
+    type: "expandable",
+    iconPath: mdiPalette,
+    schema: [
+      {
+        name: "max_consumer_branches",
+        selector: {
+          number: {
+            min: 0,
+            max: 10,
+            mode: "slider",
+          }
+        }
+      },
+      {
+        name: "hide_small_consumers",
+        selector: { boolean: {} }
+      }
+    ]
+  }
 ];
 
 @customElement(ENERGY_CARD_EDITOR_NAME)
@@ -26,11 +54,16 @@ export class EnergyFlowCardEditor extends LitElement implements LovelaceCardEdit
   }
 
   private _computeLabel = (schema: HaFormSchema) => {
-    switch (schema.name) {
-      case "title": return "Title";
+    const customLocalize = setupCustomlocalize(this.hass!);
+
+    if (GENERIC_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.generic.${schema.name}`);
     }
-    console.error("Error name key missing for '" + schema.name + "'")
-    return ""
+    if (ENERGY_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.energy_sankey.${schema.name}`);
+    } return this.hass!.localize(
+      `ui.panel.lovelace.editor.card.generic.${schema.name}`
+    );
   };
 
   protected render() {

--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -24,7 +24,10 @@ import type { LovelaceCard, LovelaceCardEditor } from "./ha/panels/lovelace/type
 import { EnergyElecFlowCardConfig } from "./types";
 
 import { registerCustomCard } from "./utils/custom-cards";
-import { ENERGY_CARD_EDITOR_NAME } from "./const";
+import {
+  ENERGY_CARD_EDITOR_NAME,
+  HIDE_CONSUMERS_BELOW_THRESHOLD_WH,
+} from "./const";
 
 registerCustomCard({
   type: "hui-energy-elec-flow-card",
@@ -85,6 +88,8 @@ export class HuiEnergyElecFlowCard
     if (!this.hass || !this._config) {
       return nothing;
     }
+    const hideConsumersBelow = this._config.hide_consumers_below
+      ? HIDE_CONSUMERS_BELOW_THRESHOLD_WH : 0;
     return html`
       <ha-card>
         ${this._config.title
@@ -101,6 +106,7 @@ export class HuiEnergyElecFlowCard
             .gridOutRoute=${this._gridOutRoute || undefined}
             .generationInRoutes=${this._generationInRoutes || {}}
             .consumerRoutes=${this._consumerRoutes || {}}
+            .hideConsumersBelow=${hideConsumersBelow}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -25,7 +25,11 @@ import { ExtEntityRegistryEntry, getExtendedEntityRegistryEntry } from "./ha/dat
 //import "./power-flow-card-editor"
 
 
-import { POWER_CARD_NAME, POWER_CARD_EDITOR_NAME } from "./const";
+import {
+  POWER_CARD_NAME,
+  POWER_CARD_EDITOR_NAME,
+  HIDE_CONSUMERS_BELOW_THRESHOLD_W,
+} from "./const";
 
 registerCustomCard({
   type: "hui-power-flow-card",
@@ -221,6 +225,9 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
 
     const maxConsumerBranches = this._config.max_consumer_branches || 0;
 
+    const hideConsumersBelow = this._config.hide_small_consumers
+      ? HIDE_CONSUMERS_BELOW_THRESHOLD_W : 0;
+
     let gridInRoute: ElecRoute | null = null;
     if (config.power_from_grid_entity) {
       const stateObj = this.hass.states[config.power_from_grid_entity];
@@ -325,6 +332,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
             .generationInRoutes=${generationInRoutes}
             .consumerRoutes=${consumerRoutes}
             .maxConsumerBranches=${maxConsumerBranches}
+            .hideConsumersBelow=${hideConsumersBelow}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -219,6 +219,8 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
       delete (config.generation_entity)
     }
 
+    const maxConsumerBranches = this._config.max_consumer_branches || 0;
+
     let gridInRoute: ElecRoute | null = null;
     if (config.power_from_grid_entity) {
       const stateObj = this.hass.states[config.power_from_grid_entity];
@@ -322,6 +324,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
             .gridOutRoute=${gridOutRoute || undefined}
             .generationInRoutes=${generationInRoutes}
             .consumerRoutes=${consumerRoutes}
+            .maxConsumerBranches=${maxConsumerBranches}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,0 +1,91 @@
+import { HomeAssistant } from "./ha/types";
+// import * as ar from "./translations/ar.json";
+// import * as bg from "./translations/bg.json";
+// import * as ca from "./translations/ca.json";
+// import * as cs from "./translations/cs.json";
+// import * as da from "./translations/da.json";
+// import * as de from "./translations/de.json";
+// import * as el from "./translations/el.json";
+import * as en from "./translations/en.json";
+// import * as es from "./translations/es.json";
+// import * as fi from "./translations/fi.json";
+// import * as fr from "./translations/fr.json";
+// import * as he from "./translations/he.json";
+// import * as hu from "./translations/hu.json";
+// import * as id from "./translations/id.json";
+// import * as it from "./translations/it.json";
+// import * as ko_KR from "./translations/ko-KR.json";
+// import * as nb from "./translations/nb.json";
+// import * as nl from "./translations/nl.json";
+// import * as pl from "./translations/pl.json";
+// import * as pt_BR from "./translations/pt-BR.json";
+// import * as pt_PT from "./translations/pt-PT.json";
+// import * as ro from "./translations/ro.json";
+// import * as ru from "./translations/ru.json";
+// import * as sl from "./translations/sl.json";
+// import * as sk from "./translations/sk.json";
+// import * as sv from "./translations/sv.json";
+// import * as tr from "./translations/tr.json";
+// import * as uk from "./translations/uk.json";
+// import * as vi from "./translations/vi.json";
+// import * as zh_Hans from "./translations/zh-Hans.json";
+// import * as zh_Hant from "./translations/zh-Hant.json";
+
+const languages: Record<string, unknown> = {
+    //   ar,
+    //   bg,
+    //   ca,
+    //   cs,
+    //   da,
+    //   de,
+    //   el,
+    en,
+    //   es,
+    //   fi,
+    //   fr,
+    //   he,
+    //   hu,
+    //   id,
+    //   it,
+    //   "ko-KR": ko_KR,
+    //   nb,
+    //   nl,
+    //   pl,
+    //   "pt-BR": pt_BR,
+    //   "pt-PT": pt_PT,
+    //   ro,
+    //   ru,
+    //   sl,
+    //   sk,
+    //   sv,
+    //   tr,
+    //   uk,
+    //   vi,
+    //   "zh-Hans": zh_Hans,
+    //   "zh-Hant": zh_Hant,
+};
+
+const DEFAULT_LANG = "en";
+
+function getTranslatedString(key: string, lang: string): string | undefined {
+    try {
+        return key
+            .split(".")
+            .reduce(
+                (o, i) => (o as Record<string, unknown>)[i],
+                languages[lang]
+            ) as string;
+    } catch (_) {
+        return undefined;
+    }
+}
+
+export default function setupCustomlocalize(hass?: HomeAssistant) {
+    return function (key: string) {
+        const lang = hass?.locale.language ?? DEFAULT_LANG;
+
+        let translated = getTranslatedString(key, lang);
+        if (!translated) translated = getTranslatedString(key, DEFAULT_LANG);
+        return translated ?? key;
+    };
+}

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -36,6 +36,16 @@ const schema = [
       }
     }
   },
+  {
+    name: "max_consumer_branches",
+    selector: {
+      number: {
+        min: 0,
+        max: 10,
+        mode: "slider",
+      }
+    }
+  }
   // { name: "group_small", selector: { boolean: {} } },
 ];
 
@@ -61,6 +71,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
       case "power_from_grid_entity": return "Power from grid";
       case "group_small": return "Group low values together";
       case "generation_entity": return "Power from generation (optional)";
+      case "max_consumer_branches": return "Limit displayed consumer branches (0 for unlimited)";
     }
     console.error("Error name key missing for '" + schema.name + "'")
     return ""
@@ -144,6 +155,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         !== this._config.generation_entity) {
         configValue = "generation_entity";
         value = value.generation_entity;
+      }
+      else if (value.max_consumer_branches
+        !== this._config.max_consumer_branches || -1) {
+        configValue = "max_consumer_branches";
+        value = value.max_consumer_branches;
       }
       else {
         console.warn("unhandled change in <ha-form>");

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -14,9 +14,17 @@ import type {
   SubElementEditorConfig,
 } from "./ha/panels/lovelace/editor/types";
 
-import { POWER_CARD_EDITOR_NAME } from "./const";
+import { GENERIC_LABELS, POWER_CARD_EDITOR_NAME } from "./const";
 import { EntityConfig, LovelaceRowConfig } from "./ha/panels/lovelace/entity-rows/types";
 import { processEditorEntities } from "./ha/panels/lovelace/editor/process-editor-entities";
+import { mdiPalette } from "@mdi/js";
+import setupCustomlocalize from "./localize";
+
+const POWER_LABELS = [
+  "power_from_grid_entity",
+  "generation_entity",
+  "hide_small_consumers",
+];
 
 const schema = [
   { name: "title", selector: { text: {} } },
@@ -37,16 +45,27 @@ const schema = [
     }
   },
   {
-    name: "max_consumer_branches",
-    selector: {
-      number: {
-        min: 0,
-        max: 10,
-        mode: "slider",
+    name: "appearance",
+    flatten: true,
+    type: "expandable",
+    iconPath: mdiPalette,
+    schema: [
+      {
+        name: "max_consumer_branches",
+        selector: {
+          number: {
+            min: 0,
+            max: 10,
+            mode: "slider",
+          }
+        }
+      },
+      {
+        name: "hide_small_consumers",
+        selector: { boolean: {} }
       }
-    }
+    ]
   }
-  // { name: "group_small", selector: { boolean: {} } },
 ];
 
 @customElement(POWER_CARD_EDITOR_NAME)
@@ -66,15 +85,17 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
   }
 
   private _computeLabel = (schema: HaFormSchema) => {
-    switch (schema.name) {
-      case "title": return "Title";
-      case "power_from_grid_entity": return "Power from grid";
-      case "group_small": return "Group low values together";
-      case "generation_entity": return "Power from generation (optional)";
-      case "max_consumer_branches": return "Limit displayed consumer branches (0 for unlimited)";
+    const customLocalize = setupCustomlocalize(this.hass!);
+
+    if (GENERIC_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.generic.${schema.name}`);
     }
-    console.error("Error name key missing for '" + schema.name + "'")
-    return ""
+    if (POWER_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.power_sankey.${schema.name}`);
+    }
+    return this.hass!.localize(
+      `ui.panel.lovelace.editor.card.generic.${schema.name}`
+    );
   };
 
   protected render() {
@@ -157,9 +178,14 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         value = value.generation_entity;
       }
       else if (value.max_consumer_branches
-        !== this._config.max_consumer_branches || -1) {
+        != this._config.max_consumer_branches || 0) {
         configValue = "max_consumer_branches";
         value = value.max_consumer_branches;
+      }
+      else if (value.hide_small_consumers
+        != this._config.hide_small_consumers) {
+        configValue = "hide_small_consumers";
+        value = value.hide_small_consumers;
       }
       else {
         console.warn("unhandled change in <ha-form>");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,0 +1,21 @@
+{
+  "editor": {
+    "card": {
+      "generic": {
+       "title": "Title",
+       "max_consumer_branches": "Limit quantity of consumer branches (0 for unlimited)",
+       "appearance": "Appearance"
+      },
+      "power_sankey": {
+        "power_from_grid_entity": "Power from grid",
+        "group_small": "Group low values together",
+        "generation_entity": "Power from generation (optional)",
+        "hide_small_consumers": "Group consumers below 100W"
+      },
+      "energy_sankey": {
+        "hide_small_consumers": "Group consumers below 0.1kWh"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Add two features for limiting what is displayed on the graph:

### Limit quantity of consumer branches

If set to a value above 2, this starts grouping consumer branches on the graph into a new name 'other'. The smallest ones are grouped first, until the total branches (including the new 'other' and 'untracked' equals the value entered on the slider).

### Group consumers below x

If turned on, this takes consumers with a value below 100W or 0,1kWh, and automatically adds them to the 'other' group.

This allows entities that frequently have a zero value to only appear on the graph when they reach a substantial amount.

Screenshots of new behaviour:
![image](https://github.com/user-attachments/assets/74bbf601-0491-4cf2-be67-daa5d46ff885)
![image](https://github.com/user-attachments/assets/c53728df-8c18-468a-aaa4-b539f8f1cf44)
![image](https://github.com/user-attachments/assets/8bfcd9d2-4b89-4d6d-ba3e-b6de302f8de7)

fixes #17