### PR TITLE
Allow kW power units to scale correctly

### DIFF
--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -38,6 +38,28 @@ registerCustomCard({
 });
 
 
+function computePower(stateObj: HassEntity): number {
+  /**
+   * Returns the power of an entity, scaled to W.
+   */
+  let uom: string | undefined;
+  let state: number = Number(stateObj.state)
+  if (uom = stateObj.attributes.unit_of_measurement) {
+    switch (uom) {
+      case "kW":  {
+        return 1000 * state;
+      }
+      default: {
+        return state;
+      }
+    }
+  }
+  else {
+    return state;
+  }
+
+}
+
 @customElement("hui-power-flow-card")
 class HuiPowerFlowCard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass!: HomeAssistant;
@@ -245,7 +267,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
       gridInRoute = {
         id: config.power_from_grid_entity,
         text: name,
-        rate: Number(stateObj.state),
+        rate: computePower(stateObj),
       };
     }
 
@@ -262,11 +284,10 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
           </hui-warning>
         `;
       }
-      const name = computeStateName(stateObj);
       gridOutRoute = {
         id: config.power_to_grid_entity,
-        text: name,
-        rate: Number(stateObj.state),
+        text: computeStateName(stateObj),
+        rate: computePower(stateObj),
       };
     }
 
@@ -281,11 +302,10 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
             </hui-warning>
           `;
         }
-        const name = computeStateName(stateObj);
         generationInRoutes[entity] = {
           id: entity,
-          text: name,
-          rate: Number(stateObj.state),
+          text: computeStateName(stateObj),
+          rate: computePower(stateObj),
           icon: mdiSolarPower,
         };
       }
@@ -310,7 +330,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
         consumerRoutes[entity.entity] = {
           id: entity.entity,
           text: name,
-          rate: Number(stateObj.state),
+          rate: computePower(stateObj),
         };
       }
     }


### PR DESCRIPTION
Highlighted in #30, if an entity had power units in kW rather than W, this was scaled incorrectly in the flow graph.

This change converts kW units into W. With this change anything anything with units kW is scaled by 1000, and everything else is scaled by 1 (this includes W, as well as no units and MW, GW, TW etc).

(so MW, GW, TW are not correctly supported yet).

Fixes #30