### PR TITLE
Fix energy consumer grouping

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -6,7 +6,7 @@ export const ENERGY_CARD_NAME = `${PREFIX_NAME}-energy-elec-flow-card`;
 export const ENERGY_CARD_EDITOR_NAME = `${ENERGY_CARD_NAME}-editor`;
 
 export const HIDE_CONSUMERS_BELOW_THRESHOLD_W = 100;
-export const HIDE_CONSUMERS_BELOW_THRESHOLD_WH = 100;
+export const HIDE_CONSUMERS_BELOW_THRESHOLD_KWH = 0.1;
 
 export const GENERIC_LABELS = [
     "appearance",

--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -26,7 +26,7 @@ import { EnergyElecFlowCardConfig } from "./types";
 import { registerCustomCard } from "./utils/custom-cards";
 import {
   ENERGY_CARD_EDITOR_NAME,
-  HIDE_CONSUMERS_BELOW_THRESHOLD_WH,
+  HIDE_CONSUMERS_BELOW_THRESHOLD_KWH,
 } from "./const";
 
 registerCustomCard({
@@ -88,8 +88,10 @@ export class HuiEnergyElecFlowCard
     if (!this.hass || !this._config) {
       return nothing;
     }
-    const hideConsumersBelow = this._config.hide_consumers_below
-      ? HIDE_CONSUMERS_BELOW_THRESHOLD_WH : 0;
+
+    const maxConsumerBranches = this._config.max_consumer_branches || 0;
+    const hideConsumersBelow = this._config.hide_small_consumers
+      ? HIDE_CONSUMERS_BELOW_THRESHOLD_KWH : 0;
     return html`
       <ha-card>
         ${this._config.title
@@ -106,6 +108,7 @@ export class HuiEnergyElecFlowCard
             .gridOutRoute=${this._gridOutRoute || undefined}
             .generationInRoutes=${this._generationInRoutes || {}}
             .consumerRoutes=${this._consumerRoutes || {}}
+            .maxConsumerBranches=${maxConsumerBranches}
             .hideConsumersBelow=${hideConsumersBelow}
           ></ha-elec-sankey>
         </div>


### PR DESCRIPTION
The grouping feature in the appearance section of the editor was not working for the energy graph.

This PR enables that feature to work in the same way as the power graph.

The threshold for grouping small items together is set to a fixed value of 0.1kWh