### PR TITLE
Use display name when available

### DIFF
--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -177,7 +177,7 @@ export class HuiEnergyElecFlowCard
       .device_consumption as DeviceConsumptionEnergyPreference[];
 
     consumers.forEach((consumer) => {
-      const label = getStatisticLabel(
+      const label = consumer.name || getStatisticLabel(
         this.hass,
         consumer.stat_consumption,
         undefined


### PR DESCRIPTION
As suggested by @BJReplay...

A display name is available for individual consumers, configurable on the energy dashboard. This typically allows shorter names to be shown.

For the avoidance of confusion, there are 3 'names' for the entity:

- The entity id e.g. `sensor.power_sensor_1`
- The 'friendly name' e.g. "Power Sensor Within Living Room Lamp"
- The 'display name' e.g. "Living Room Lamp"

This PR uses the display name when it is available. If this returns an invalid string for any reason, it drops back to the friendly name.

The code change to implement this was v minor.

Tested and working on my setup. 

Fixes #34 