### PR TITLE
Issue46 from battery positive

### DIFF
--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -26,6 +26,8 @@ export class HuiEntitiesCardRowEditor extends LitElement {
 
   @property() public label?: string;
 
+  @property() public subLabel?: string;
+
   private _entityKeys = new WeakMap<LovelaceRowConfig, string>();
 
   private _getKey(action: LovelaceRowConfig) {
@@ -85,6 +87,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
                         allow-custom-entity
                         include-device-classes=${deviceClassesFilter}
                         hideClearIcon
+                        label=${this.subLabel || nothing}
                         .hass=${this.hass}
                         .value=${(entityConf as EntityConfig).entity}
                         .index=${index}
@@ -108,6 +111,7 @@ export class HuiEntitiesCardRowEditor extends LitElement {
       <ha-entity-picker
         class="add-entity"
         include-device-classes=${deviceClassesFilter}
+        label=${this.subLabel || nothing}
         .hass=${this.hass}
         @value-changed=${this._addEntity}
       ></ha-entity-picker>

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -380,12 +380,12 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
           in: {
             id: entity.entity,
             text: name,
-            rate: powerIn < 0 ? -powerIn : 0,
+            rate: powerIn > 0 ? powerIn : 0,
           },
           out: {
             id: "null",
             text: "null",
-            rate: powerIn > 0 ? powerIn : 0,
+            rate: powerIn < 0 ? -powerIn : 0,
           }
         };
       }

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -131,6 +131,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         .hass=${this.hass}
         id="battery-entities"
         label="Battery Entities (Optional)"
+        subLabel="Power from battery (one combined in/out per battery, positive = discharging)"
         .entities=${this._configBatteryEntities}
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}


### PR DESCRIPTION
Currently a positive value for the battery entity is used to mean power going into the battery. This is the opposite of popular cards/integrations such as tesla powerwall.

This PR inverts it.

At the same time the wording is improved on the edit card, so that users understand they are adding one combined entity per battery.

Fixes #46