### PR TITLE
Issue45 migrate config without error

### DIFF
--- a/src/ha-elec-sankey.ts
+++ b/src/ha-elec-sankey.ts
@@ -43,7 +43,6 @@ export class HaElecSankey extends ElecSankey {
   ): TemplateResult {
     const _id = id || "";
     const numFractionDigits = this.unit === "kWh" ? 1 : 0;
-    console.log("displayClass: ", displayClass);
     return html`
       <div
         class="label ${id ? "label-action-clickable " : ""}${displayClass}"

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -190,7 +190,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
      * HA configures *energy* sources, not power sources, so we look for the
      * original devices associated with each energy source, and find an
      * associated power sensor for each.
-     * It's not perfect, but even if a partially populated config is a huge
+     * It's not perfect, but even a partially populated config is a huge
      * help to the user.
      */
 

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -24,6 +24,31 @@ import { getEnergyPreferences } from "./ha/data/energy";
 import { ExtEntityRegistryEntry, getExtendedEntityRegistryEntry } from "./ha/data/entity_registry";
 //import "./power-flow-card-editor"
 
+export function verifyAndMigrateConfig(config: PowerFlowCardConfig) {
+  if (!config) {
+    throw new Error("Invalid configuration");
+  }
+  let newConfig = { ...config };
+
+  if (!config.config_version) {
+    console.log("Migrating config from ? to version 1");
+    newConfig.config_version = 1;
+    newConfig.battery_entities = newConfig.battery_entities || [];
+    newConfig.hide_small_consumers = newConfig.hide_small_consumers || false;
+    newConfig.max_consumer_branches = newConfig.max_consumer_branches || 0;
+  }
+
+  if (
+    !config.power_from_grid_entity &&
+    !config.power_to_grid_entity &&
+    !config.generation_entity &&
+    config.consumer_entities.length === 0
+  ) {
+    throw new Error("Must specify at least one entity");
+  }
+
+  return newConfig;
+}
 
 import {
   POWER_CARD_NAME,
@@ -78,23 +103,9 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
   }
 
   public setConfig(config: PowerFlowCardConfig): void {
-    if (
-      !config.power_from_grid_entity &&
-      !config.power_to_grid_entity &&
-      !config.generation_entity &&
-      config.consumer_entities.length === 0
-    ) {
-      throw new Error("Must specify at least one entity");
-    }
 
-    let newConfig = { ...config };
-    if (newConfig.battery_entities === undefined) {
-      newConfig.battery_entities = [];
-      newConfig.config_version = 1;
-    }
-
-    // @todo consider adding more config checks here.
-    this._config = { ...newConfig };
+    const newConfig = verifyAndMigrateConfig(config);
+    this._config = {...newConfig};
   }
 
   private static async getExtendedEntityRegistryEntries(_hass: HomeAssistant): Promise<{ [id: string]: ExtEntityRegistryEntry }> {

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -19,6 +19,7 @@ import { EntityConfig, LovelaceRowConfig } from "./ha/panels/lovelace/entity-row
 import { processEditorEntities } from "./ha/panels/lovelace/editor/process-editor-entities";
 import { mdiPalette } from "@mdi/js";
 import setupCustomlocalize from "./localize";
+import { verifyAndMigrateConfig } from "./hui-power-flow-card";
 
 const POWER_LABELS = [
   "power_from_grid_entity",
@@ -82,9 +83,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
   @state() private _subElementEditorConfig?: SubElementEditorConfig;
 
   public setConfig(config: PowerFlowCardConfig): void {
-    this._config = config;
-    this._configBatteryEntities = processEditorEntities(config.battery_entities);
-    this._configConsumerEntities = processEditorEntities(config.consumer_entities);
+    this._config = verifyAndMigrateConfig(config);
+    this._configBatteryEntities = 
+        processEditorEntities(this._config.battery_entities);
+    this._configConsumerEntities = 
+        processEditorEntities(this._config.consumer_entities);
   }
 
   private _computeLabel = (schema: HaFormSchema) => {
@@ -138,7 +141,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
       <elec-sankey-hui-entities-card-row-editor
         .hass=${this.hass}
         id="consumer-entities"
-        label="Consumer Entities (required)"
+        label="Consumer Entities (Required)"
         .entities=${this._configConsumerEntities}
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}


### PR DESCRIPTION
Fixes issue where old config would result in error when trying to edit card.

Migration is now fully supported and the config version is tracked.
Upgrades are supported, downgrades are not.

Fixes #45