### PR TITLE
Allow battery power direction to be flipped

### DIFF
--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -386,7 +386,8 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
         }
         // power in refers to power into the energy distribution system
         // (i.e. out of the battery)
-        let powerIn = computePower(stateObj) 
+        let powerIn = (this._config.invert_battery_flows ? -1 : 1) 
+          * computePower(stateObj);
         batteryRoutes[entity.entity] = {
           in: {
             id: entity.entity,

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -30,12 +30,20 @@ export function verifyAndMigrateConfig(config: PowerFlowCardConfig) {
   }
   let newConfig = { ...config };
 
-  if (!config.config_version) {
+  let currentVersion = config.config_version || 0;
+
+  if (currentVersion === 0) {
     console.log("Migrating config from ? to version 1");
-    newConfig.config_version = 1;
+    currentVersion = 1;
     newConfig.battery_entities = newConfig.battery_entities || [];
     newConfig.hide_small_consumers = newConfig.hide_small_consumers || false;
     newConfig.max_consumer_branches = newConfig.max_consumer_branches || 0;
+  }
+  if (currentVersion === 1) {
+    // Migrate from version 1 to version 2
+    console.log("Migrating config from version 1 to version 2");
+    currentVersion = 2;
+    newConfig.invert_battery_flows = false;
   }
 
   if (
@@ -46,6 +54,7 @@ export function verifyAndMigrateConfig(config: PowerFlowCardConfig) {
   ) {
     throw new Error("Must specify at least one entity");
   }
+  newConfig.config_version = currentVersion;
 
   return newConfig;
 }

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -25,6 +25,7 @@ const POWER_LABELS = [
   "power_from_grid_entity",
   "generation_entity",
   "hide_small_consumers",
+  "invert_battery_flows",
 ];
 
 const schema = [
@@ -63,6 +64,10 @@ const schema = [
       },
       {
         name: "hide_small_consumers",
+        selector: { boolean: {} }
+      },
+      {
+        name: "invert_battery_flows",
         selector: { boolean: {} }
       }
     ]
@@ -108,6 +113,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
     if (!this.hass || !this._config) {
       return nothing;
     }
+    const customLocalize = setupCustomlocalize(this.hass!);
     // Unused feature - may be reinstated if we allow renaming sub-elements.
     //  if (this._subElementEditorConfig) {
     //   return html`
@@ -122,6 +128,10 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
     // }
 
     const data = { ...this._config } as any;
+
+    const batteryHint = data.invert_battery_flows 
+      ? customLocalize(`editor.card.power_sankey.battery_hint_inverted`)
+      : customLocalize(`editor.card.power_sankey.battery_hint_std`);
     return html`
       <ha-form
         .hass=${this.hass}
@@ -134,7 +144,7 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         .hass=${this.hass}
         id="battery-entities"
         label="Battery Entities (Optional)"
-        subLabel="Power from battery (one combined in/out per battery, positive = discharging)"
+        subLabel=${batteryHint}
         .entities=${this._configBatteryEntities}
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}
@@ -203,6 +213,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         != this._config.hide_small_consumers) {
         configValue = "hide_small_consumers";
         value = value.hide_small_consumers;
+      }
+      else if (value.invert_battery_flows
+        != this._config.invert_battery_flows) {
+        configValue = "invert_battery_flows";
+        value = value.invert_battery_flows;
       }
       else {
         console.warn("unhandled change in <ha-form>");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,7 +10,10 @@
         "power_from_grid_entity": "Power from grid",
         "group_small": "Group low values together",
         "generation_entity": "Power from generation (optional)",
-        "hide_small_consumers": "Group consumers below 100W"
+        "hide_small_consumers": "Group consumers below 100W",
+        "invert_battery_flows": "Battery flows are positive for charging",
+        "battery_hint_std": "Power from battery (one combined in/out per battery, positive = discharging)",
+        "battery_hint_inverted": "Power to battery (one combined in/out per battery, positive = charging)"
       },
       "energy_sankey": {
         "hide_small_consumers": "Group consumers below 0.1kWh"


### PR DESCRIPTION
The default behaviour is that positive battery flow indicates flow of electrical power into the household energy system.

Some users have reported that this is the inverse of what their battery reports, i.e. a positive value indicates flowing into the battery.

This PR adds a toggle to the appearance section to allow it to be flipped.

Fixes #55