### PR TITLE
Fix unknown source when discharging to grid

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -611,7 +611,7 @@ export class ElecSankey extends LitElement {
     x =
       this._gridExport +
       generationToBatteriesTemp -
-      (generationTrackedTotal + gridToBatteriesTemp);
+      (generationTrackedTotal + gridToBatteriesTemp + batteryInTotal);
     if (x > 0) {
       phantomGeneration = x;
     }


### PR DESCRIPTION
Fix issue identified in #59.

There was a small error in the logic where battery sources were ignored in a certain scenario when trying to calculate whether a phantom generation source was necessary.

@BJReplay thanks for helping identify this