### PR TITLE
Fix unnecessary residual untracked consumer

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -733,13 +733,12 @@ export class ElecSankey extends LitElement {
             rate: phantomGeneration,
           }
         : undefined;
-    if (untrackedConsumer > 0) {
-      this._untrackedConsumerRoute = {
-        id: "untracked",
-        text: "Untracked",
-        rate: untrackedConsumer,
-      };
-    }
+    this._untrackedConsumerRoute = {
+      id: "untracked",
+      text: "Untracked",
+      rate: untrackedConsumer > 0 ? untrackedConsumer : 0,
+    };
+    
 
     /**
      * Calculate and update a scaling factor to make the UI look sensible.


### PR DESCRIPTION
In some scenarios, the diagram does not warrant the creation of an untracked consumer but one is created anyway.

It would usually be a small value but not zero.

This turned out to be the phantom consumer existing from previous iterations with the same objects, but not actually being set to zero when the calculation result required a zero value consumer.

This PR fixes the issue by changing the logic to set the phantom consumer to zero if no phantom consumer is needed.

Fixes #61

![image](https://github.com/user-attachments/assets/4cff54a0-3c64-49ef-bb7e-2e3d3055e12e)


