### PR TITLE
Hide upper tier consumers to fix double counting

### DIFF
--- a/src/ha/data/energy.ts
+++ b/src/ha/data/energy.ts
@@ -96,6 +96,7 @@ export interface DeviceConsumptionEnergyPreference {
   // This is an ever increasing value
   stat_consumption: string;
   name?: string;
+  included_in_stat?: string;  
 }
 
 export interface FlowFromGridSourceEnergyPreference {

--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -176,7 +176,18 @@ export class HuiEnergyElecFlowCard
     const consumers: DeviceConsumptionEnergyPreference[] = energyData.prefs
       .device_consumption as DeviceConsumptionEnergyPreference[];
 
-    consumers.forEach((consumer) => {
+    // Filter out consumers that are higher level measurements in the hierarchy
+    let consumerBlacklist: string[] = [];
+    consumers.forEach((consumer: DeviceConsumptionEnergyPreference) => {
+      if (consumer.included_in_stat !== undefined) {
+        consumerBlacklist.push(consumer.included_in_stat);
+      }
+    });
+    
+    consumers.forEach((consumer: DeviceConsumptionEnergyPreference) => {
+      if (consumerBlacklist.includes(consumer.stat_consumption)) {
+        return;
+      }
       const label = consumer.name || getStatisticLabel(
         this.hass,
         consumer.stat_consumption,


### PR DESCRIPTION
In HA 2025.4, a new feature was been added that allows the energy config to specify when an energy entity is included in an higher tier entity.

That feature resolved an issue with the default HA dashboards that would double count some energy values, particularly if users had energy metering on individual breakers as well as the end consumer device.

That double counting was occurring within the Energy Sankey Card too, resulting in more consumption than was actually occurring. This in turn would sometimes result in a phantom generation source being displayed to balance the books (see #70).

This PR analyses the energy preference config during import and makes a blacklist of any sensor IDs that feature in the 'included_in_stat' field for any of the consumers. Then those consumers are ignored from the energy sankey and the default configuration of the power sankey.

Note that this PR fixes the energy sankey and should fix existing configurations, but the power sankey card is autoconfigured once then saved. It should fix newly autoconfigured power sankey cards, but existing ones will need to be manually edited if the user has not done so already.

Fixes #70