### PR TITLE
Treat NaN/undef as 0 when grouping low consumers

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -1424,10 +1424,10 @@ export class ElecSankey extends LitElement {
         consumerRoutes = this.consumerRoutes;
         const sortedConsumerRoutes: ElecRoute[] = Object.values(
           this.consumerRoutes
-        ).sort((a, b) => a.rate - b.rate);
+        ).sort((a, b) => (a.rate || 0) - (b.rate || 0));
         sortedConsumerRoutes.forEach((route) => {
           if (otherCount > 0) {
-            groupedConsumer.rate += route.rate;
+            groupedConsumer.rate += route.rate || 0;
             groupedConsumerExists = true;
             if (route.id) {
               delete consumerRoutes[route.id];

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -1408,8 +1408,9 @@ export class ElecSankey extends LitElement {
 
     if (this.hideConsumersBelow > 0) {
       for (const key in consumerRoutes) {
-        if (consumerRoutes[key].rate < this.hideConsumersBelow) {
-          groupedConsumer.rate += consumerRoutes[key].rate;
+        let rate = consumerRoutes[key].rate || 0; // Treat undef/NaN as 0
+        if (rate < this.hideConsumersBelow) {
+          groupedConsumer.rate += rate;
           groupedConsumerExists = true;
           delete consumerRoutes[key];
         }


### PR DESCRIPTION
When grouping consumers to hide values below a threshold, or to limit the number of branches, consumers reporting 'Not A Number' (NaN) or undefined were not being handled correctly. They would be ignored from the filter, and in some cases break the summation, meaning the 'other' total showed 0 when that sum included positive values as well as at least one NaN.

This PR fixes this by reading all NaN/undefined values as 0 for the purpose of filtering/adding

Fixes #71