### PR TITLE
Allow separate grid in/out to be specified on power card

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -10,6 +10,7 @@ export const HIDE_CONSUMERS_BELOW_THRESHOLD_KWH = 0.1;
 
 export const GENERIC_LABELS = [
     "appearance",
+    "advanced_options",
     "title",
     "max_consumer_branches",
 ];

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -483,6 +483,9 @@ export class ElecSankey extends LitElement {
     if (this.gridInRoute) {
       return this.gridInRoute.rate > 0 ? this.gridInRoute.rate : 0;
     }
+    else if (this.gridOutRoute) {
+      return this.gridOutRoute.rate < 0 ? -this.gridOutRoute.rate : 0;
+    }
     return 0;
   }
 
@@ -1071,7 +1074,8 @@ export class ElecSankey extends LitElement {
     y10: number,
     svgScaleX: number = 1
   ): [TemplateResult | symbol, TemplateResult | symbol] {
-    if (!this.gridInRoute) {
+    const gridRoute = this.gridInRoute ? this.gridInRoute : this.gridOutRoute;
+    if (!gridRoute) {
       return [nothing, nothing];
     }
     const arrow_head_length = ARROW_HEAD_LENGTH / svgScaleX;
@@ -1089,7 +1093,7 @@ export class ElecSankey extends LitElement {
       top: ${midY * svgScaleX}px; margin: ${-divHeight / 2}px 0 0 0px;"
     >
       ${this._generateLabelDiv(
-        this.gridInRoute.id,
+        gridRoute.id,
         mdiTransmissionTower,
         undefined,
         rateA,

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -327,7 +327,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
     }
 
     let gridOutRoute: ElecRoute | null = null;
-    if (config.power_to_grid_entity) {
+    if (config.independent_grid_in_out && config.power_to_grid_entity) {
       const stateObj = this.hass.states[config.power_to_grid_entity];
       if (!stateObj) {
         return html`

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -23,6 +23,7 @@ import { verifyAndMigrateConfig } from "./hui-power-flow-card";
 
 const POWER_LABELS = [
   "power_from_grid_entity",
+  "power_to_grid_entity",
   "generation_entity",
   "hide_small_consumers",
   "invert_battery_flows",
@@ -32,6 +33,14 @@ const schema = [
   { name: "title", selector: { text: {} } },
   {
     name: "power_from_grid_entity", selector: {
+      entity: {
+        domain: "sensor",
+        device_class: "power",
+      }
+    }
+  },
+  {
+    name: "power_to_grid_entity", selector: {
       entity: {
         domain: "sensor",
         device_class: "power",
@@ -198,6 +207,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         !== this._config.power_from_grid_entity) {
         configValue = "power_from_grid_entity";
         value = value.power_from_grid_entity;
+      }
+      else if (value.power_to_grid_entity
+        !== this._config.power_to_grid_entity) {
+        configValue = "power_to_grid_entity";
+        value = value.power_to_grid_entity;
       }
       else if (value.generation_entity
         !== this._config.generation_entity) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -4,7 +4,8 @@
       "generic": {
        "title": "Title",
        "max_consumer_branches": "Limit quantity of consumer branches (0 for unlimited)",
-       "appearance": "Appearance"
+       "appearance": "Appearance",
+       "advanced_options": "Advanced Options"
       },
       "power_sankey": {
         "power_from_grid_entity": "Power from grid (optional)",
@@ -14,7 +15,8 @@
         "hide_small_consumers": "Group consumers below 100W",
         "invert_battery_flows": "Battery flows are positive for charging",
         "battery_hint_std": "Power from battery (one combined in/out per battery, positive = discharging)",
-        "battery_hint_inverted": "Power to battery (one combined in/out per battery, positive = charging)"
+        "battery_hint_inverted": "Power to battery (one combined in/out per battery, positive = charging)",
+        "independent_grid_in_out": "Use separate sensors for grid in/out"
       },
       "energy_sankey": {
         "hide_small_consumers": "Group consumers below 0.1kWh"

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7,7 +7,8 @@
        "appearance": "Appearance"
       },
       "power_sankey": {
-        "power_from_grid_entity": "Power from grid",
+        "power_from_grid_entity": "Power from grid (optional)",
+        "power_to_grid_entity": "Power to grid (optional)",
         "group_small": "Group low values together",
         "generation_entity": "Power from generation (optional)",
         "hide_small_consumers": "Group consumers below 100W",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   power_from_grid_entity?: string;
   power_to_grid_entity?: string;
   generation_entity?: string;
+  hide_small_consumers?: boolean;
+  independent_grid_in_out?: boolean;
   consumer_entities: {
     entity: string;
     name?: string;


### PR DESCRIPTION
Some systems have separate entities for power in/out, rather than one entity that goes positive/negative for import/export.

In addition, see #76, sometimes the grid power sensor uses positive to represent export, and negative to represent import.

This PR adds the ability to separately specify grid in and out, as two entities.

I'm slightly reluctant to add this, because <0.5% of users seem to have this issue, and having two entities for the grid connection will probably confuse a lot of people.

I may add a toggle to in the display section, to turn on the secondary grid interface option (default this to off), e.g. "my system uses two separate entities to measure grid import/export power".

Fixes #58 