### PR TITLE
Provide option to show battery charge coming exclusively from generation

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -431,6 +431,9 @@ export class ElecSankey extends LitElement {
   @property({ attribute: false })
   public hideConsumersBelow: number = 0;
 
+  @property({ attribute: false })
+  public batteryChargeOnlyFromGeneration: boolean = false;
+
   private _rateToWidthMultplier: number = 0.2;
 
   private _phantomGridInRoute?: ElecRoute;
@@ -599,15 +602,25 @@ export class ElecSankey extends LitElement {
     // Whatever battery out is not going to the grid must be going to consumers.
     let batteriesToConsumersTemp = batteryInTotal - batteriesToGridTemp;
 
-    // We then proceed on the basis that the full flow into the battery is
-    // coming from the grid (as far as the grid input allows). If there is
-    // more flow coming into the batteries than the grid would allow, we
-    // assume that the additional flow is coming from generation.
-    if (gridImport > batteriesOutTotal) {
-      gridToBatteriesTemp = batteriesOutTotal;
+    // The user can specify that their batteries are only charged from 
+    // generation. 
+    if (this.batteryChargeOnlyFromGeneration) {
+      // In this case, we assume that all the flow into the
+      // batteries is coming from generation, and the grid is not contributing
+      // at all.
+      gridToBatteriesTemp = 0;
+      generationToBatteriesTemp = batteriesOutTotal;
     } else {
-      gridToBatteriesTemp = gridImport;
-      generationToBatteriesTemp = batteriesOutTotal - gridToBatteriesTemp;
+      // Otherwise, we proceed on the basis that the full flow into the battery 
+      // is coming from the grid (as far as the grid input allows). If there is
+      // more flow coming into the batteries than the grid would allow, we
+      // assume that the additional flow is coming from generation.
+      if (gridImport > batteriesOutTotal) {
+        gridToBatteriesTemp = batteriesOutTotal;
+      } else {
+        gridToBatteriesTemp = gridImport;
+        generationToBatteriesTemp = batteriesOutTotal - gridToBatteriesTemp;
+      }
     }
     // If we have exceeded the total generation by doing this, we must
     // recalculate the phantom generation source.

--- a/src/energy-flow-card-editor.ts
+++ b/src/energy-flow-card-editor.ts
@@ -14,6 +14,7 @@ import setupCustomlocalize from "./localize";
 
 const ENERGY_LABELS = [
   "hide_small_consumers",
+  "battery_charge_only_from_generation",
 ]
 const schema = [
   { name: "title", selector: { text: {} } },
@@ -37,7 +38,12 @@ const schema = [
       {
         name: "hide_small_consumers",
         selector: { boolean: {} }
+      },
+      {
+        name: "battery_charge_only_from_generation",
+        selector: { boolean: {} }
       }
+
     ]
   }
 ];

--- a/src/hui-energy-elec-flow-card.ts
+++ b/src/hui-energy-elec-flow-card.ts
@@ -95,6 +95,8 @@ export class HuiEnergyElecFlowCard
     const maxConsumerBranches = this._config.max_consumer_branches || 0;
     const hideConsumersBelow = this._config.hide_small_consumers
       ? HIDE_CONSUMERS_BELOW_THRESHOLD_KWH : 0;
+    const batteryChargeOnlyFromGeneration = 
+      this._config.battery_charge_only_from_generation || false;
     return html`
       <ha-card>
         ${this._config.title
@@ -114,6 +116,7 @@ export class HuiEnergyElecFlowCard
             .batteryRoutes=${this._batteryRoutes || {}} 
             .maxConsumerBranches=${maxConsumerBranches}
             .hideConsumersBelow=${hideConsumersBelow}
+            .batteryChargeOnlyFromGeneration=${batteryChargeOnlyFromGeneration}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -304,6 +304,8 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
 
     const hideConsumersBelow = this._config.hide_small_consumers
       ? HIDE_CONSUMERS_BELOW_THRESHOLD_W : 0;
+    const batteryChargeOnlyFromGeneration = 
+        this._config.battery_charge_only_from_generation || false;
 
     let gridInRoute: ElecRoute | null = null;
     if (config.power_from_grid_entity) {
@@ -444,6 +446,7 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
             .batteryRoutes=${batteryRoutes}
             .maxConsumerBranches=${maxConsumerBranches}
             .hideConsumersBelow=${hideConsumersBelow}
+            .batteryChargeOnlyFromGeneration=${batteryChargeOnlyFromGeneration}
           ></ha-elec-sankey>
         </div>
       </ha-card>

--- a/src/hui-power-flow-card.ts
+++ b/src/hui-power-flow-card.ts
@@ -301,7 +301,6 @@ class HuiPowerFlowCard extends LitElement implements LovelaceCard {
     }
 
     const maxConsumerBranches = this._config.max_consumer_branches || 0;
-
     const hideConsumersBelow = this._config.hide_small_consumers
       ? HIDE_CONSUMERS_BELOW_THRESHOLD_W : 0;
     const batteryChargeOnlyFromGeneration = 

--- a/src/power-flow-card-editor.ts
+++ b/src/power-flow-card-editor.ts
@@ -27,6 +27,7 @@ const POWER_LABELS = [
   "generation_entity",
   "hide_small_consumers",
   "invert_battery_flows",
+  "battery_charge_only_from_generation",
   "independent_grid_in_out",
 ];
 
@@ -95,6 +96,10 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
           },
           {
             name: "invert_battery_flows",
+            selector: { boolean: {} }
+          },
+          {
+            name: "battery_charge_only_from_generation",
             selector: { boolean: {} }
           },
         ]
@@ -250,6 +255,11 @@ export class PowerFlowCardEditor extends LitElement implements LovelaceCardEdito
         != this._config.invert_battery_flows) {
         configValue = "invert_battery_flows";
         value = value.invert_battery_flows;
+      }
+      else if (value.battery_charge_only_from_generation
+        != this._config.battery_charge_only_from_generation) {
+        configValue = "battery_charge_only_from_generation";
+        value = value.battery_charge_only_from_generation;
       }
       else if (value.independent_grid_in_out
         != this._config.independent_grid_in_out) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -20,7 +20,8 @@
         "independent_grid_in_out": "Use separate sensors for grid in/out"
       },
       "energy_sankey": {
-        "hide_small_consumers": "Group consumers below 0.1kWh"
+        "hide_small_consumers": "Group consumers below 0.1kWh",
+        "battery_charge_only_from_generation": "Batteries can only charge from generated energy"
       }
     }
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -14,6 +14,7 @@
         "generation_entity": "Power from generation (optional)",
         "hide_small_consumers": "Group consumers below 100W",
         "invert_battery_flows": "Battery flows are positive for charging",
+        "battery_charge_only_from_generation": "Batteries can only charge from generated power",
         "battery_hint_std": "Power from battery (one combined in/out per battery, positive = discharging)",
         "battery_hint_inverted": "Power to battery (one combined in/out per battery, positive = charging)",
         "independent_grid_in_out": "Use separate sensors for grid in/out"

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface PowerFlowCardConfig extends LovelaceCardConfig {
   power_to_grid_entity?: string;
   generation_entity?: string;
   hide_small_consumers?: boolean;
+  battery_charge_only_from_generation?: boolean;
   independent_grid_in_out?: boolean;
   consumer_entities: {
     entity: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import { LovelaceCardConfig } from "./ha/data/lovelace/config/card";
 export interface EnergyElecFlowCardConfig extends LovelaceCardConfig {
   title?: string;
   collection_key?: string;
+  battery_charge_only_from_generation?: boolean;
 }
 
 export interface PowerFlowCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
See #84 
In some setups, batteries are exclusively charged from solar/generation sources, i.e. it is electrically impossible for them to be charged from the grid in source.

The existing logic for drawing the graph doesnt know which electrons go where, so leans towards showing charging coming from the grid, when grid power is present. This creates a diagram that is invalid in some setups.

This PR adds an option to the UI in both power and energy graphs, to show battery charging exclusively from generation.

When enabled, no grid power/energy will flow to the batteries. It will all come exclusively from generation, creating a phantom generation source if necessary to achieve this.

Fixes #84