### PR TITLE
Display consumers in order of size in power and energy graphs

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -1414,7 +1414,12 @@ export class ElecSankey extends LitElement {
 
   private _getGroupedConsumerRoutes(): { [id: string]: ElecRoute } {
     let consumerRoutes: { [id: string]: ElecRoute } = {};
-    consumerRoutes = structuredClone(this.consumerRoutes);
+    const entries: Array<[string, ElecRoute]> 
+      = Object.entries(this.consumerRoutes);
+    entries.sort(([,routeA], [, routeB]) => routeB.rate - routeA.rate);
+    for (const [key, val] of Object.entries(entries)) {
+      consumerRoutes[key] = val[1];
+    }    
 
     let groupedConsumer: ElecRoute = {
       id: "other",


### PR DESCRIPTION
Currently the consumers are displayed in the order they are added.

It is preferable to sort them in order so that bigger ones are at the top.

'Untracked' and 'other' remain at the bottom.

Fixes #87

A small disadvantage is that the order can change live while user is watching, as consumption increases/decreases, but this can already happen with consumers going in and out of the 'other' group, so not considered to be a major issue.