### PR TITLE
Include battery flows in max trunk width calculation

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -775,6 +775,7 @@ export class ElecSankey extends LitElement {
 
     this._batteriesToGridRate = batteriesToGridTemp;
     this._batteriesToConsumersRate = batteriesToConsumersTemp;
+    const batteriesTotal = batteriesToGridTemp + batteriesToConsumersTemp;
 
     this._generationToConsumersRate = generationToConsumersTemp;
     this._generationToBatteriesRate = generationToBatteriesTemp;
@@ -783,7 +784,8 @@ export class ElecSankey extends LitElement {
     this._gridToBatteriesRate = gridToBatteriesTemp;
     this._gridToConsumersRate = gridToConsumersTemp;
 
-    const widest_trunk = Math.max(genTotal, gridInTotal, consumerTotal, 1.0);
+    const widest_trunk = Math.max(genTotal, gridInTotal, consumerTotal, 
+      batteriesTotal, 1.0);
     this._rateToWidthMultplier = TARGET_SCALED_TRUNK_WIDTH / widest_trunk;
   }
 


### PR DESCRIPTION
In certain conditions, flows would look too wide, e.g. with lots of battery flow and not much else.

This was caused by battery flows being omitted from the max trunk width calculation. This PR adds them back in.

Fixes #96