### PR TITLE
Make consumer arrow heads fixed length

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -410,8 +410,8 @@ function renderBlendRect(
 
 @customElement("elec-sankey")
 export class ElecSankey extends LitElement {
-  // Extras can be added in to the left of the arrow by extending this
-  // class and overriding extrasLength.
+  // Extras can be added in to the left of the consumer arrow by
+  // extending this class and overriding extrasLength.
   static extrasLength = 0;
 
   @property()


### PR DESCRIPTION
Some refactoring and reformatting

Put consumer arrow head in own div to prevent stretching

Add facility to insert extra elements before the arrow head.

Fixes #99 