### PR TITLE
Handle edge case where total flow=0 causes divide-by-0 error

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -1774,6 +1774,9 @@ export class ElecSankey extends LitElement {
     battToConsFlow: number
   ): string {
     const total = genToConsFlow + gridToConsFlow + battToConsFlow;
+    if (total === 0) {
+      return this._gridColor();
+    }
     return mix3Hexes(
       this._genColor(),
       this._gridColor(),


### PR DESCRIPTION
SSIA