### PR TITLE
Add more translation keys

### DIFF
--- a/src/cards/energy-card/energy-elec-flow-card-editor.ts
+++ b/src/cards/energy-card/energy-elec-flow-card-editor.ts
@@ -61,7 +61,7 @@ export class EnergyFlowCardEditor
     this._config = verifyAndMigrateConfig(config);
   }
 
-  private _computeLabel = (schema: HaFormSchema) => {
+  private _computeLabel = (schema: HaFormSchema): string => {
     const customLocalize = setupCustomlocalize(this.hass!);
 
     if (GENERIC_LABELS.includes(schema.name)) {

--- a/src/cards/energy-card/energy-elec-flow-card.ts
+++ b/src/cards/energy-card/energy-elec-flow-card.ts
@@ -33,6 +33,8 @@ import {
   ENERGY_CARD_NAME,
   HIDE_CONSUMERS_BELOW_THRESHOLD_KWH,
 } from "./const";
+import { ElecFlowCardBase } from "../../shared/elec-flow-card-base";
+import setupCustomlocalize from "../../localize";
 
 const DEFAULT_CONFIG: EnergyElecFlowCardConfig = {
   type: `custom:${ENERGY_CARD_NAME}`,
@@ -70,11 +72,9 @@ registerCustomCard({
 
 @customElement(ENERGY_CARD_NAME)
 export class EnergyElecFlowCard
-  extends SubscribeMixin(LitElement)
+  extends ElecFlowCardBase
   implements LovelaceCard
 {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
   @state() private _config?: EnergyElecFlowCardConfig;
 
   @state() private _gridInRoute?: ElecRoute;
@@ -112,8 +112,13 @@ export class EnergyElecFlowCard
     this._config = verifyAndMigrateConfig(config);
   }
 
-  static getStubConfig(): EnergyElecFlowCardConfig {
-    return DEFAULT_CONFIG;
+  static getStubConfig(hass: HomeAssistant): EnergyElecFlowCardConfig {
+    // We don't have access to instance localizer yet, so set up a temp one.
+    const localize = setupCustomlocalize(hass);
+    let config = DEFAULT_CONFIG;
+    config.title = localize("card.energy_sankey.energy_distribution_today");
+
+    return config;
   }
 
   protected render() {

--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -34,6 +34,8 @@ import {
   POWER_CARD_EDITOR_NAME,
   HIDE_CONSUMERS_BELOW_THRESHOLD_W,
 } from "./const";
+import { ElecFlowCardBase } from "../../shared/elec-flow-card-base";
+import setupCustomlocalize from "../../localize";
 
 const DEFAULT_CONFIG: PowerFlowCardConfig = {
   type: `custom:${POWER_CARD_NAME}`,
@@ -127,9 +129,7 @@ function htmlHuiWarning(hass: HomeAssistant, entity: string): TemplateResult {
 }
 
 @customElement(POWER_CARD_NAME)
-export class PowerFlowCard extends LitElement implements LovelaceCard {
-  @property({ attribute: false }) public hass!: HomeAssistant;
-
+export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   @state() protected _config?: PowerFlowCardConfig;
 
   public static async getConfigElement(): Promise<LovelaceCardEditor> {
@@ -254,7 +254,10 @@ export class PowerFlowCard extends LitElement implements LovelaceCard {
     const extEntities: { [id: string]: ExtEntityRegistryEntry } =
       await this.getExtendedEntityRegistryEntries(_hass);
 
+    // We don't have access to instance localizer here, so set up a temp one.
+    const localize = setupCustomlocalize(_hass);
     let returnConfig: PowerFlowCardConfig = DEFAULT_CONFIG;
+    returnConfig.title = localize("card.power_sankey.live_power_flow");
     // Parse energy sources from HA's energy prefs
     for (const source of energyPrefs.energy_sources) {
       switch (source.type) {

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -470,6 +470,11 @@ export class ElecSankey extends LitElement {
 
   private _generationToConsumersRate: number = 0;
 
+  protected _localize = (key: string, fallBack?: string) => {
+    // This is a simple localizer that can be overridden by the parent class.
+    return fallBack || key;
+  };
+
   private _generationTrackedTotal(): number {
     let totalGen = 0;
     for (const key in this.generationInRoutes) {
@@ -758,7 +763,7 @@ export class ElecSankey extends LitElement {
         : undefined;
     this._untrackedConsumerRoute = {
       id: UNTRACKED_ID,
-      text: "Untracked",
+      text: this._localize("untracked", "Untracked"),
       rate: untrackedConsumer > 0 ? untrackedConsumer : 0,
     };
 
@@ -1445,7 +1450,7 @@ export class ElecSankey extends LitElement {
 
     let groupedConsumer: ElecRoute = {
       id: OTHER_ID,
-      text: "Other",
+      text: this._localize("other", "Other"),
       rate: 0,
     };
     let groupedConsumerExists = false;

--- a/src/ha-elec-sankey.ts
+++ b/src/ha-elec-sankey.ts
@@ -7,6 +7,7 @@ import { HomeAssistant } from "./ha/types";
 import { formatNumber } from "./ha/common/number/format_number";
 
 import { fireEvent } from "./ha/common/dom/fire_event";
+import setupCustomlocalize from "./localize";
 
 // Additional items from frontend src/dialogs/more-info/ha-more-info-dialog.ts
 type View = "info" | "history" | "settings" | "related";
@@ -29,6 +30,25 @@ declare global {
 @customElement("ha-elec-sankey")
 export class HaElecSankey extends ElecSankey {
   @property({ attribute: false }) public hass!: HomeAssistant;
+
+  private _localizer: (key: string) => string = (key: string): string => {
+    return key;
+  };
+
+  private _localizerIsSetup = false;
+
+  protected _localize = (key: string): string => {
+    if (!this._localizerIsSetup) {
+      this._localizer = setupCustomlocalize(this.hass);
+      this._localizerIsSetup = true;
+    }
+    // The low level card ElecSankey doesn't know anything about the card
+    // prefix, so we need to add it here.
+    if (!key.startsWith("card.")) {
+      key = "card.generic." + key;
+    }
+    return this._localizer(key);
+  };
 
   protected _generateLabelDiv(
     id: string | undefined,

--- a/src/shared/elec-flow-card-base.ts
+++ b/src/shared/elec-flow-card-base.ts
@@ -1,0 +1,24 @@
+import { LitElement } from "lit";
+import { SubscribeMixin } from "../ha/mixins/subscribe-mixin";
+import setupCustomlocalize from "../localize";
+import { property } from "lit/decorators";
+import { HomeAssistant } from "../ha/types";
+
+export class ElecFlowCardBase extends SubscribeMixin(LitElement) {
+  @property({ attribute: false }) public hass!: HomeAssistant;
+
+  private _localizer: (key: string) => string = (key: string): string => {
+    return key;
+  };
+
+  private _localizerIsSetup = false;
+
+  protected _localize = (key: string): string => {
+    if (!this._localizerIsSetup) {
+      this._localizer = setupCustomlocalize(this.hass);
+      this._localizerIsSetup = true;
+    }
+    console.info("[ElecFlowCardBase] Localizing key:", key);
+    return this._localizer(key);
+  };
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -14,10 +14,10 @@
   "editor": {
     "card": {
       "generic": {
-       "title": "Title",
-       "max_consumer_branches": "Limit quantity of consumer branches (0 for unlimited)",
-       "appearance": "Appearance",
-       "advanced_options": "Advanced Options"
+        "title": "Title",
+        "max_consumer_branches": "Limit quantity of consumer branches (0 for unlimited)",
+        "appearance": "Appearance",
+        "advanced_options": "Advanced Options"
       },
       "power_sankey": {
         "power_from_grid_entity": "Power from grid (optional)",
@@ -37,4 +37,3 @@
     }
   }
 }
-

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,16 @@
 {
+  "card": {
+    "generic": {
+      "other": "Other",
+      "untracked": "Untracked"
+    },
+    "power_sankey": {
+      "live_power_flow": "Live power flow"
+    },
+    "energy_sankey": {
+      "energy_distribution_today": "Energy distribution today"
+    }
+  },
   "editor": {
     "card": {
       "generic": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,4 +1,16 @@
 {
+  "card": {
+    "generic": {
+      "other": "Autre",
+      "untracked": "Non suivi"
+    },
+    "power_sankey": {
+      "live_power_flow": "Flux d'énergie en direct"
+    },
+    "energy_sankey": {
+      "energy_distribution_today": "Répartition de l'énergie aujourd'hui"
+    }
+  },
   "editor": {
     "card": {
       "generic": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -14,10 +14,10 @@
   "editor": {
     "card": {
       "generic": {
-       "title": "Titre",
-       "max_consumer_branches": "Limiter le nombre de consommateur (0 pour illimité)",
-       "appearance": "Apparence",
-       "advanced_options": "Options avancée"
+        "title": "Titre",
+        "max_consumer_branches": "Limiter le nombre de consommateur (0 pour illimité)",
+        "appearance": "Apparence",
+        "advanced_options": "Options avancée"
       },
       "power_sankey": {
         "power_from_grid_entity": "Puissance depuis le réseaux (optionnel)",


### PR DESCRIPTION
So far only certain keys could be translated. This was limited to UI elements in the editor.

With this PR it is possible to translate:
 - Words such as 'Other' and 'Untracked' in the sankey charts
 - Default titles for the cards

The framework has been set up so that all of these and more can be defined in `mylanguage.json` files.

The code should fall back to displaying a default value or the translation key if a string is missing.

Fixes #134 