### PR TITLE
Fix missing icon/text for phantom grid in/out

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -535,6 +535,8 @@ export class ElecSankey extends LitElement {
       return this.gridInRoute.rate > 0 ? this.gridInRoute.rate : 0;
     } else if (this.gridOutRoute) {
       return this.gridOutRoute.rate < 0 ? -this.gridOutRoute.rate : 0;
+    } else if (this._phantomGridInRoute) {
+      return this._phantomGridInRoute.rate;
     }
     return 0;
   }
@@ -1140,7 +1142,14 @@ export class ElecSankey extends LitElement {
     y10: number,
     svgScaleX: number
   ): [TemplateResult | symbol, TemplateResult | symbol] {
-    const gridRoute = this.gridInRoute ? this.gridInRoute : this.gridOutRoute;
+    let gridRoute: ElecRoute | undefined = undefined;
+    if (this.gridInRoute) {
+      gridRoute = { ...this.gridInRoute, icon: mdiTransmissionTower };
+    } else if (this.gridOutRoute) {
+      gridRoute = { ...this.gridOutRoute, icon: mdiTransmissionTower };
+    } else if (this._phantomGridInRoute) {
+      gridRoute = { ...this._phantomGridInRoute, icon: mdiHelpRhombus };
+    }
     if (!gridRoute) {
       return [nothing, nothing];
     }
@@ -1160,7 +1169,7 @@ export class ElecSankey extends LitElement {
     >
       ${this._generateLabelDiv(
         gridRoute.id,
-        mdiTransmissionTower,
+        gridRoute.icon,
         undefined,
         rateA,
         rateB,

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -1142,14 +1142,11 @@ export class ElecSankey extends LitElement {
     y10: number,
     svgScaleX: number
   ): [TemplateResult | symbol, TemplateResult | symbol] {
-    let gridRoute: ElecRoute | undefined = undefined;
-    if (this.gridInRoute) {
-      gridRoute = { ...this.gridInRoute, icon: mdiTransmissionTower };
-    } else if (this.gridOutRoute) {
-      gridRoute = { ...this.gridOutRoute, icon: mdiTransmissionTower };
-    } else if (this._phantomGridInRoute) {
-      gridRoute = { ...this._phantomGridInRoute, icon: mdiHelpRhombus };
-    }
+    const gridRoute =
+      this.gridInRoute ||
+      this.gridOutRoute ||
+      this._phantomGridInRoute ||
+      undefined;
     if (!gridRoute) {
       return [nothing, nothing];
     }
@@ -1169,7 +1166,7 @@ export class ElecSankey extends LitElement {
     >
       ${this._generateLabelDiv(
         gridRoute.id,
-        gridRoute.icon,
+        gridRoute.icon || mdiTransmissionTower,
         undefined,
         rateA,
         rateB,


### PR DESCRIPTION
If the user has not configured a grid in/out source and the algorithm detects that power is coming from the grid, a 'phantom grid in source' is created internally.

This is how the graph displays something meaningful, even though no sensor exists.

But there was a problem in the logic, meaning that no icon or values were being displayed in this case.

This PR fixes the problem.

Thanks @AJErazzor for reporting this!

Fixes #132 