### PR TITLE
Make energy card work even if no grid in/out configured in HA energy dashboard

### DIFF
--- a/src/cards/energy-card/energy-elec-flow-card.ts
+++ b/src/cards/energy-card/energy-elec-flow-card.ts
@@ -167,8 +167,8 @@ export class EnergyElecFlowCard
     const prefs = energyData.prefs;
     const types = energySourcesByType(prefs);
 
-    if (types.grid && types.grid.length >= 1) {
-      if (types.grid[0].flow_from.length >= 1) {
+    if (types.grid && types.grid.length > 0) {
+      if (types.grid[0].flow_from.length > 0) {
         const totalFromGrid =
           calculateStatisticsSumGrowth(
             energyData.stats,

--- a/src/cards/energy-card/energy-elec-flow-card.ts
+++ b/src/cards/energy-card/energy-elec-flow-card.ts
@@ -167,27 +167,32 @@ export class EnergyElecFlowCard
     const prefs = energyData.prefs;
     const types = energySourcesByType(prefs);
 
-    const totalFromGrid =
-      calculateStatisticsSumGrowth(
-        energyData.stats,
-        types.grid![0].flow_from.map((flow) => flow.stat_energy_from)
-      ) ?? 0;
-    const gridInId = types.grid![0].flow_from[0].stat_energy_from;
-    this._gridInRoute = {
-      id: gridInId,
-      rate: totalFromGrid,
-    };
-
-    const totalToGrid =
-      calculateStatisticsSumGrowth(
-        energyData.stats,
-        types.grid![0].flow_to.map((flow) => flow.stat_energy_to)
-      ) ?? 0;
-    const gridOutId = types.grid![0].flow_to[0].stat_energy_to;
-    this._gridOutRoute = {
-      id: gridOutId,
-      rate: totalToGrid,
-    };
+    if (types.grid && types.grid.length >= 1) {
+      if (types.grid[0].flow_from.length >= 1) {
+        const totalFromGrid =
+          calculateStatisticsSumGrowth(
+            energyData.stats,
+            types.grid[0].flow_from.map((flow) => flow.stat_energy_from)
+          ) ?? 0;
+        const gridInId = types.grid[0].flow_from[0].stat_energy_from;
+        this._gridInRoute = {
+          id: gridInId,
+          rate: totalFromGrid,
+        };
+      }
+      if (types.grid[0].flow_to.length >= 1) {
+        const totalToGrid =
+          calculateStatisticsSumGrowth(
+            energyData.stats,
+            types.grid[0].flow_to.map((flow) => flow.stat_energy_to)
+          ) ?? 0;
+        const gridOutId = types.grid[0].flow_to[0].stat_energy_to;
+        this._gridOutRoute = {
+          id: gridOutId,
+          rate: totalToGrid,
+        };
+      }
+    }
 
     solarSources.forEach((source) => {
       const label = getStatisticLabel(

--- a/src/cards/energy-card/energy-elec-flow-card.ts
+++ b/src/cards/energy-card/energy-elec-flow-card.ts
@@ -180,7 +180,7 @@ export class EnergyElecFlowCard
           rate: totalFromGrid,
         };
       }
-      if (types.grid[0].flow_to.length >= 1) {
+      if (types.grid[0].flow_to.length > 0) {
         const totalToGrid =
           calculateStatisticsSumGrowth(
             energyData.stats,


### PR DESCRIPTION
Reported by @newhinton

If the user did not configure either grid in or out in the energy dashboard, the energy card would cause an unhandled exception on the browser console each time it loaded, and the displayed graph was incomplete.

This PR fixes the issue by explicitly handling the case where there those config settings not present. 

The card can already cope with this, by calculating/infefring from other sensors.Of course if the user has grid in/out sensors, they should be configured for the best results.

Fixes #133