### PR TITLE
Fix problem where generation source would not show on power card

### DIFF
--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -379,7 +379,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
     }
 
     const generationInRoutes: { [id: string]: ElecRoute } = {};
-    for (const entity of [config.generation_entity]) {
+    for (const entity of [config.generation_entities]) {
       if (!entity) {
         continue;
       }

--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -379,7 +379,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
     }
 
     const generationInRoutes: { [id: string]: ElecRoute } = {};
-    for (const entity of [config.generation_entities]) {
+    for (const entity of config.generation_entities) {
       if (!entity) {
         continue;
       }


### PR DESCRIPTION
As of 0.0.23, the power flow card does not display the true solar sensor input, even if it is configured.

A phantom generation source is shown in some scenarios (assumed to be when grid in is configured).

Reported by @AJErazzor

This PR fixes the issue by using the correct iterator for the generation sources which I expect was broken during recent refactoring.

Fixes #146 