### PR TITLE
Issue149 fix consumer and battery selector in UI

### DIFF
--- a/src/cards/power-card/power-flow-card-editor.ts
+++ b/src/cards/power-card/power-flow-card-editor.ts
@@ -21,6 +21,7 @@ import {
   LovelaceRowConfig,
 } from "../../ha/panels/lovelace/entity-rows/types";
 import { processEditorEntities } from "../../ha/panels/lovelace/editor/process-editor-entities";
+import "../../ha/panels/lovelace/editor/hui-entities-card-row-editor";
 import { mdiPalette, mdiWrench } from "@mdi/js";
 import setupCustomlocalize from "../../localize";
 import { verifyAndMigrateConfig } from "./power-flow-card";

--- a/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
+++ b/src/ha/panels/lovelace/editor/hui-entities-card-row-editor.ts
@@ -242,6 +242,6 @@ export class HuiEntitiesCardRowEditor extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "hui-entities-card-row-editor": HuiEntitiesCardRowEditor;
+    "elec-sankey-hui-entities-card-row-editor": HuiEntitiesCardRowEditor;
   }
 }


### PR DESCRIPTION
The consumer and battery selectors were missing from the UI in the power card editor.

This PR reinstates them.

Fixes #149