### PR TITLE
Fix issue where power card did not display if no solar was configured

### DIFF
--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -339,10 +339,9 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
     | TemplateResult {
     // The editor only supports a single generation entity, so we need to
     // convert the single entity to an array.
-    if (config.generation_entity) {
-      config.generation_entities = [config.generation_entity];
-      delete config.generation_entity;
-    }
+    config.generation_entities = config.generation_entity
+      ? [config.generation_entity]
+      : [];
 
     let gridInRoute: ElecRoute | null = null;
     if (config.power_from_grid_entity) {


### PR DESCRIPTION
When the power card is loading values, it must manipulate the config because the yaml and UI config can only handle one generation entity, but the underlying card can handle a list of generation entities.

The case of no generation was not being handled correctly, instead creating an invalid iterator that would iterate, leading to console errors and no displayed power card.

This PR fixes the issue by defaulting to an empty list in that condition.

There is also no need to delete the dict member, so that has been removed.

Fixes #157