### PR TITLE
Use the word home instead of untracked for 0 consumers

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -798,9 +798,14 @@ export class ElecSankey extends LitElement {
             rate: phantomGeneration,
           }
         : undefined;
+    // if we aren't tracking any consumers, use the word 'Home'
+    const untrackedName =
+      consumerTrackedTotal != 0
+        ? this._localize("untracked", "Untracked")
+        : this._localize("home", "Home");
     this._untrackedConsumerRoute = {
       id: UNTRACKED_ID,
-      text: this._localize("untracked", "Untracked"),
+      text: untrackedName,
       rate: untrackedConsumer > 0 ? untrackedConsumer : 0,
     };
 

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -799,8 +799,7 @@ export class ElecSankey extends LitElement {
           }
         : undefined;
     // if we aren't tracking any consumers, use the word 'Home'
-    const untrackedName =
-      consumerTrackedTotal != 0
+      consumerTrackedTotal !== 0
         ? this._localize("untracked", "Untracked")
         : this._localize("home", "Home");
     this._untrackedConsumerRoute = {


### PR DESCRIPTION
Some users set up this card with no consumers configured (i.e. no energy monitoring of end devices). They just want a display of what is going into the home, vs back out to the grid etc.

Those people don't like the word 'untracked'.

If the user has configured 0 consumers, show that as 'Home' instead.

This creates a new translation key.

Fixes #169 