### PR TITLE
Use the word home instead of untracked for 0 consumers (part 2)

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -799,6 +799,7 @@ export class ElecSankey extends LitElement {
           }
         : undefined;
     // if we aren't tracking any consumers, use the word 'Home'
+    const untrackedName =
       consumerTrackedTotal !== 0
         ? this._localize("untracked", "Untracked")
         : this._localize("home", "Home");


### PR DESCRIPTION
Fix a line that was missed in #172