### PR TITLE
Add translation keys for 'home'

### DIFF
--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -2,6 +2,7 @@
   "card": {
     "generic": {
       "other": "Ostatní",
+      "home": "Domov",
       "untracked": "Nerozlišeno"
     },
     "power_sankey": {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -2,6 +2,7 @@
   "card": {
     "generic": {
       "other": "Andere",
+      "home": "Zuhause",
       "untracked": "nicht überwacht"
     },
     "power_sankey": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2,6 +2,7 @@
   "card": {
     "generic": {
       "other": "Other",
+      "home": "Home",
       "untracked": "Untracked"
     },
     "power_sankey": {

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -2,6 +2,7 @@
   "card": {
     "generic": {
       "other": "Autre",
+      "home": "Maison",
       "untracked": "Non suivi"
     },
     "power_sankey": {

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -2,6 +2,7 @@
   "card": {
     "generic": {
       "other": "Altro",
+      "home": "Casa",
       "untracked": "Non tracciati"
     },
     "power_sankey": {


### PR DESCRIPTION
#169 added a new feature to display the word 'Home' instead of untracked.

I've got some candidate translations for the new word in the attached pull request. Please could the native speakers check that it sounds ok?

This word will be displayed if there is only one energy/power flow due to having no specific consumer energy/power monitoring, e.g.
<img width="424" height="202" alt="image" src="https://github.com/user-attachments/assets/39dc9bcf-485f-4994-aa97-168d3a87701c" />
