### PR TITLE
added option to modify names to be displayed in power card

### DIFF
--- a/src/cards/power-card/power-flow-card-editor.ts
+++ b/src/cards/power-card/power-flow-card-editor.ts
@@ -25,6 +25,7 @@ import "../../ha/panels/lovelace/editor/hui-entities-card-row-editor";
 import { mdiPalette, mdiWrench } from "@mdi/js";
 import { setupCustomlocalize } from "../../localize";
 import { verifyAndMigrateConfig } from "./power-flow-card";
+import { ConsumerEntity, BatteryEntity } from "../../types";
 
 const POWER_LABELS = [
   "power_from_grid_entity",
@@ -194,6 +195,7 @@ export class PowerFlowCardEditor
         .entities=${this._configBatteryEntities}
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}
+        nameEditable
       ></elec-sankey-hui-entities-card-row-editor>
       <elec-sankey-hui-entities-card-row-editor
         .hass=${this.hass}
@@ -203,6 +205,7 @@ export class PowerFlowCardEditor
         includeDeviceClasses=${["power"]}
         @entities-changed=${this._valueChanged}
         @edit-detail-element=${this._editDetailElement}
+        nameEditable
       ></elec-sankey-hui-entities-card-row-editor>
       <ha-alert alert-type="info">
         Please note that this card is in development! If you see a bug or a
@@ -381,5 +384,41 @@ export class PowerFlowCardEditor
 
   private _goBack(): void {
     this._subElementEditorConfig = undefined;
+  }
+
+  // Add a method to handle name changes
+  private _handleNameChange(ev: CustomEvent): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const target = ev.target as HTMLElement;
+    const index = Number(target.getAttribute("data-index"));
+    const type = target.getAttribute("data-type");
+    const newName = (ev.target as HTMLInputElement).value;
+
+    if (type === "consumer") {
+      const newConsumerEntities = [...this._config.consumer_entities];
+      newConsumerEntities[index] = {
+        ...newConsumerEntities[index],
+        name: newName || undefined,
+      };
+      this._config = {
+        ...this._config,
+        consumer_entities: newConsumerEntities,
+      };
+    } else if (type === "battery") {
+      const newBatteryEntities = [...this._config.battery_entities];
+      newBatteryEntities[index] = {
+        ...newBatteryEntities[index],
+        name: newName || undefined,
+      };
+      this._config = {
+        ...this._config,
+        battery_entities: newBatteryEntities,
+      };
+    }
+
+    fireEvent(this, "config-changed", { config: this._config });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,13 +10,21 @@ export interface EnergyElecFlowCardConfig extends ElecFlowCardConfig {
   collection_key?: string; // @todo this might not be needed.
 }
 
+interface ConsumerEntity {
+  entity: string;
+  name?: string;
+}
+
+interface BatteryEntity {
+  entity: string;
+  name?: string;
+}
+
 export interface PowerFlowCardConfig extends ElecFlowCardConfig {
   power_from_grid_entity?: string;
   power_to_grid_entity?: string;
   generation_entity?: string;
   independent_grid_in_out?: boolean;
-  consumer_entities: {
-    entity: string;
-    name?: string;
-  }[];
+  consumer_entities: ConsumerEntity[];
+  battery_entities: BatteryEntity[];
 }


### PR DESCRIPTION
As I agree with @Roving-Ronin in #167 that it would be great to have the option to rename power card entities (have some with quite "unfriendly" names myself), I decided to try implementing this nice feature. Leveraging some AI assistants, I arrived at this working solution, which I successfully tested on my own setup in Home Assistant on my Raspberry Pi.

It takes the familiar logic and steps for naming, which are
1. Allow setting custom names for consumer and battery entities in the card configuration
(_battery naming with the perspective that this might be useful later on for several batteries to be distinguished by more than just an icon_)
3. Display custom names if set, falling back to entity friendly names
4. Preserve custom names when editing the card configuration

All of this should maintain backwards compatibility with existing configurations, it didn't break my own at least. Please give it a try with your own.

Many thanks for reviewing, would be great to have this released for everyone!