### PR TITLE
Fix #179 where phantom grid source would turn on and off

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -530,12 +530,12 @@ export class ElecSankey extends LitElement {
     return this._generationTrackedTotal() + this._generationPhantom();
   }
 
-  private _gridImport(): number {
+  private _gridImport(excludePhantom: boolean = false): number {
     if (this.gridInRoute) {
       return this.gridInRoute.rate > 0 ? this.gridInRoute.rate : 0;
     } else if (this.gridOutRoute) {
       return this.gridOutRoute.rate < 0 ? -this.gridOutRoute.rate : 0;
-    } else if (this._phantomGridInRoute) {
+    } else if (!excludePhantom && this._phantomGridInRoute) {
       return this._phantomGridInRoute.rate;
     }
     return 0;
@@ -602,7 +602,7 @@ export class ElecSankey extends LitElement {
      * each flow only possible to be in or out (not both), but they are both
      * calculated using the same algorithm, documented inline below.
      */
-    const gridImport = this._gridImport();
+    const gridImport = this._gridImport(true);
 
     // Determine the grid import and export
     if (this.gridOutRoute) {
@@ -633,7 +633,7 @@ export class ElecSankey extends LitElement {
     let x = this._gridExport - generationTrackedTotal - batteryInTotal;
     if (x > 0) {
       // If this is the case, we create a phantom generation source
-      // of sufficient value to balance thie equation, and assume that all
+      // of sufficient value to balance the equation, and assume that all
       // battery power is going to the grid.
       phantomGeneration = x;
       batteriesToGridTemp = batteryInTotal;
@@ -723,7 +723,7 @@ export class ElecSankey extends LitElement {
 
     // Do we have an excess of consumption?
     x = consumerTrackedTotal - consumerTotalA;
-    if (x > 0) {
+    if (x > 0.1) {
       // There is an unknown energy source.
       if (this.gridInRoute === undefined && this.gridOutRoute === undefined) {
         // If we aren't tracking grid sources, create a phantom one.
@@ -744,7 +744,7 @@ export class ElecSankey extends LitElement {
       generationToBatteriesTemp +
       generationToConsumersTemp -
       generationTrackedTotal;
-    if (x > 0) {
+    if (x > 0.1) {
       phantomGeneration = x;
       // generationToConsumersTemp =
       //   generationTrackedTotal +

--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -70,6 +70,8 @@ const SVG_LHS_VISIBLE_WIDTH = 110;
 
 export const PAD_ANTIALIAS = 0.5;
 
+const ZERO_CHECK_TOLERANCE = 0.1;
+
 const UNTRACKED_ID = "untracked";
 const OTHER_ID = "other";
 
@@ -723,7 +725,7 @@ export class ElecSankey extends LitElement {
 
     // Do we have an excess of consumption?
     x = consumerTrackedTotal - consumerTotalA;
-    if (x > 0.1) {
+    if (x > ZERO_CHECK_TOLERANCE) {
       // There is an unknown energy source.
       if (this.gridInRoute === undefined && this.gridOutRoute === undefined) {
         // If we aren't tracking grid sources, create a phantom one.
@@ -744,7 +746,7 @@ export class ElecSankey extends LitElement {
       generationToBatteriesTemp +
       generationToConsumersTemp -
       generationTrackedTotal;
-    if (x > 0.1) {
+    if (x > ZERO_CHECK_TOLERANCE) {
       phantomGeneration = x;
       // generationToConsumersTemp =
       //   generationTrackedTotal +


### PR DESCRIPTION
Fixes an issue where if the user had not configured a grid in source or solar source, a phantom source would be created that sometimes randomly switched on and off as a grid in source, or switched between a grid and solar source.

The problem was caused by the `phantomGridInRoute` persisting between updates and the previous value propagating into the next calculation.

This PR fixes the issue by excluding the phantom source from the numbers during the first part of the calculation.

Fixes #179

Also fixed a comment typo and made the logic more resilient to 'check for floating point zero' potential errors.