### PR TITLE
Enable export arrow/value to be hidden when not needed

### DIFF
--- a/src/elec-sankey.ts
+++ b/src/elec-sankey.ts
@@ -931,7 +931,8 @@ export class ElecSankey extends LitElement {
     valueB: number | undefined = undefined,
     _valueAColor: string | undefined = undefined,
     _valueBColor: string | undefined = undefined,
-    _displayClass: string | undefined = undefined
+    _displayClass: string | undefined = undefined,
+    _: boolean = true
   ): TemplateResult {
     const valueARounded = Math.round(valueA * 10) / 10;
     const valueBRounded = valueB ? Math.round(valueB * 10) / 10 : undefined;
@@ -1165,6 +1166,9 @@ export class ElecSankey extends LitElement {
 
     const midY = (y10 + y13) / 2;
     const divHeight = ICON_SIZE_PX + TEXT_PADDING + FONT_SIZE_PX * 2;
+    const hasGridExport =
+      Object.keys(this.batteryRoutes).length > 0 ||
+      Object.keys(this.generationInRoutes).length > 0;
     const divRet = html`<div
       width=${ICON_SIZE_PX * 2}
       class="label elecroute-label-grid"
@@ -1179,7 +1183,8 @@ export class ElecSankey extends LitElement {
         rateB,
         undefined,
         undefined,
-        "grid"
+        "grid",
+        hasGridExport
       )}
     </div>`;
 

--- a/src/ha-elec-sankey.ts
+++ b/src/ha-elec-sankey.ts
@@ -58,7 +58,8 @@ export class HaElecSankey extends ElecSankey {
     valueB: number | undefined,
     valueAColor: string | undefined = undefined,
     valueBColor: string | undefined = undefined,
-    displayClass: string | undefined = undefined
+    displayClass: string | undefined = undefined,
+    showLeftValue: boolean = true
   ): TemplateResult {
     const _id = id || "";
     const numFractionDigits = this.unit === "kWh" ? 1 : 0;
@@ -70,7 +71,7 @@ export class HaElecSankey extends ElecSankey {
     >${_name || nothing}${icon
         ? html`<ha-svg-icon id=${_id} .path=${icon}> </ha-svg-icon>`
         : nothing}${valueB !== undefined
-        ? html`<br /><span
+        ? html`<br />${showLeftValue ? html`<span
               class="directionleft ${displayClass}"
               style=${valueBColor ? `color:${valueBColor}` : nothing}
               id=${_id}
@@ -80,7 +81,7 @@ export class HaElecSankey extends ElecSankey {
               >${formatNumber(valueB, this.hass.locale, {
                 maximumFractionDigits: numFractionDigits,
               })}&nbsp;${this.unit}</span
-            ><br />
+            >`: nothing}<br />
             <span
               class="directionright ${displayClass}"
               style=${valueAColor ? `color:${valueAColor}` : nothing}


### PR DESCRIPTION
The sankey chart previously showed an export arrow whether or not the user had any capability of exporting. This value and icon was pointless in those setups because it always displayed zero. The export colour (purple) also had no meaning as a result.

This PR hides the export arrow if there are no source entities (generation or batteries) configured.

Fixes #190 
