### PR TITLE
Fix max calculation bug when auto configuring power entities

### DIFF
--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -210,6 +210,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
       for (let powerEntityId of powerEntityIds) {
         const power = Math.abs(+_hass.states[powerEntityId].state);
         if (power > maxPower) {
+          maxPower = power;
           mostLikelyPowerEntityId = powerEntityId;
         }
       }


### PR DESCRIPTION
I noticed that the sankey on my hass setup wasn't showing some of my entities, I believe it is related to this max checker.

It seems in the existing case, it grabs the last entity in the powerEntityIds array, rather than the one with the maximum abs power.