### PR TITLE
Add option to hide devices with zero consumption

### DIFF
--- a/src/cards/power-card/power-flow-card-editor.ts
+++ b/src/cards/power-card/power-flow-card-editor.ts
@@ -31,6 +31,7 @@ const POWER_LABELS = [
   "power_to_grid_entity",
   "generation_entity",
   "hide_small_consumers",
+  "hide_zero_consumers",
   "invert_battery_flows",
   "battery_charge_only_from_generation",
   "independent_grid_in_out",
@@ -107,6 +108,10 @@ export class PowerFlowCardEditor
             selector: { boolean: {} },
           },
           {
+            name: "hide_zero_consumers",
+            selector: { boolean: {} },
+          },
+          {
             name: "invert_battery_flows",
             selector: { boolean: {} },
           },
@@ -134,10 +139,10 @@ export class PowerFlowCardEditor
   public setConfig(config: PowerFlowCardConfig): void {
     this._config = verifyAndMigrateConfig(config);
     this._configBatteryEntities = processEditorEntities(
-      this._config.battery_entities
+      this._config.battery_entities,
     );
     this._configConsumerEntities = processEditorEntities(
-      this._config.consumer_entities
+      this._config.consumer_entities,
     );
   }
 
@@ -151,7 +156,7 @@ export class PowerFlowCardEditor
       return customLocalize(`editor.card.power_sankey.${schema.name}`);
     }
     return this.hass!.localize(
-      `ui.panel.lovelace.editor.card.generic.${schema.name}`
+      `ui.panel.lovelace.editor.card.generic.${schema.name}`,
     );
   };
 
@@ -264,6 +269,11 @@ export class PowerFlowCardEditor
         configValue = "hide_small_consumers";
         value = value.hide_small_consumers;
       } else if (
+        value.hide_zero_consumers != this._config.hide_zero_consumers
+      ) {
+        configValue = "hide_zero_consumers";
+        value = value.hide_zero_consumers;
+      } else if (
         value.invert_battery_flows != this._config.invert_battery_flows
       ) {
         configValue = "invert_battery_flows";
@@ -306,7 +316,7 @@ export class PowerFlowCardEditor
           consumer_entities: newConfigEntities,
         };
         this._configConsumerEntities = processEditorEntities(
-          this._config!.consumer_entities
+          this._config!.consumer_entities,
         );
       } else if (
         ev.currentTarget &&
@@ -317,7 +327,7 @@ export class PowerFlowCardEditor
           battery_entities: newConfigEntities,
         };
         this._configBatteryEntities = processEditorEntities(
-          this._config!.battery_entities
+          this._config!.battery_entities,
         );
       }
     } else if (configValue) {

--- a/src/cards/power-card/power-flow-card.ts
+++ b/src/cards/power-card/power-flow-card.ts
@@ -48,6 +48,7 @@ const DEFAULT_CONFIG: PowerFlowCardConfig = {
   power_to_grid_entity: undefined,
   invert_battery_flows: false,
   hide_small_consumers: false,
+  hide_zero_consumers: false,
   max_consumer_branches: 0,
   independent_grid_in_out: false,
 };
@@ -147,7 +148,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   }
 
   private static async getExtendedEntityRegistryEntries(
-    _hass: HomeAssistant
+    _hass: HomeAssistant,
   ): Promise<{ [id: string]: ExtEntityRegistryEntry }> {
     // Get the full list of all extended entity registry entries as a dict.
 
@@ -167,7 +168,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   private static async getPowerEntityIdForEnergyEntityId(
     _hass: HomeAssistant,
     energyEntityId: string,
-    extEntities: { [id: string]: ExtEntityRegistryEntry }
+    extEntities: { [id: string]: ExtEntityRegistryEntry },
   ): Promise<string> {
     /**
      * Given an energy entity ID, find the associated power entity ID.
@@ -221,7 +222,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   private static async getPowerEntityIdForEnergyEntityIdWithFail(
     _hass: HomeAssistant,
     energyEntityId: string,
-    extEntities: { [id: string]: ExtEntityRegistryEntry }
+    extEntities: { [id: string]: ExtEntityRegistryEntry },
   ): Promise<string> {
     /**
      * Given an energy entity ID, find the associated power entity ID.
@@ -230,7 +231,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
     let powerEntityId = await this.getPowerEntityIdForEnergyEntityId(
       _hass,
       energyEntityId,
-      extEntities
+      extEntities,
     );
     if (!powerEntityId) {
       powerEntityId =
@@ -240,7 +241,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   }
 
   public static async getStubConfig(
-    _hass: HomeAssistant
+    _hass: HomeAssistant,
   ): Promise<PowerFlowCardConfig> {
     /**
      * We go on a bit of a hunt to get the stub config.
@@ -268,7 +269,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
             await this.getPowerEntityIdForEnergyEntityIdWithFail(
               _hass,
               source.stat_energy_from!,
-              extEntities
+              extEntities,
             );
           returnConfig.power_from_grid_entity = power_from_grid_entity;
           break;
@@ -278,7 +279,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
           generation_entity = await this.getPowerEntityIdForEnergyEntityId(
             _hass,
             source.stat_energy_from,
-            extEntities
+            extEntities,
           );
           if (generation_entity) {
             returnConfig.generation_entity = generation_entity;
@@ -289,7 +290,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
           batteryEntity = await this.getPowerEntityIdForEnergyEntityId(
             _hass,
             source.stat_energy_from,
-            extEntities
+            extEntities,
           );
           if (batteryEntity) {
             returnConfig.battery_entities.push({ entity: batteryEntity });
@@ -318,7 +319,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
       const entityId = await this.getPowerEntityIdForEnergyEntityId(
         _hass,
         consumer.stat_consumption,
-        extEntities
+        extEntities,
       );
       if (entityId) {
         returnConfig.consumer_entities.push({ entity: entityId });
@@ -328,7 +329,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
   }
 
   protected _getValues(
-    config: PowerFlowCardConfig
+    config: PowerFlowCardConfig,
   ):
     | [
         ElecRoute | null,
@@ -352,7 +353,7 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
           <hui-warning>
             ${createEntityNotFoundWarning(
               this.hass,
-              config.power_from_grid_entity
+              config.power_from_grid_entity,
             )}
           </hui-warning>
         `;
@@ -407,10 +408,14 @@ export class PowerFlowCard extends ElecFlowCardBase implements LovelaceCard {
         if (!name) {
           name = computeStateName(stateObj);
         }
+        const rate = computePower(stateObj);
+        if (config.hide_zero_consumers && Math.abs(rate) == 0) {
+          continue;
+        }
         consumerRoutes[entity.entity] = {
           id: entity.entity,
           text: name,
-          rate: computePower(stateObj),
+          rate: rate,
         };
       }
     }

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Export do sítě (nepovinné)",
         "generation_entity": "Výroba (nepovinné)",
         "hide_small_consumers": "Nerozlišovat spotřebu pod 20W",
+        "hide_zero_consumers": "Skrýt zařízení s nulovým odběrem",
         "invert_battery_flows": "Nabíjení baterie je kladné číslo",
         "battery_charge_only_from_generation": "Baterie se nabíjejí pouze z vyrobené energie",
         "battery_hint_std": "Energie z baterií (kombinované nabíjení/vybíjení, kladná hodnota = vybíjení)",

--- a/src/translations/da.json
+++ b/src/translations/da.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Energi til nettet (optional)",
         "generation_entity": "Energi fra produktion (optional)",
         "hide_small_consumers": "Gruppér under 20W",
+        "hide_zero_consumers": "Skjul enheder uden forbrug",
         "invert_battery_flows": "Batteri flow er positiv ved opladning",
         "battery_charge_only_from_generation": "Batterier kan kun oplade fra produceret energi",
         "battery_hint_std": "Energi fra batteri (En samlet for ind/ud per batteri, positiv = afladning)",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Netzeinspeisung (optional)",
         "generation_entity": "Solarleistung (optional)",
         "hide_small_consumers": "Gruppiere Verbraucher unter 20W",
+        "hide_zero_consumers": "Geräte ohne Verbrauch ausblenden",
         "invert_battery_flows": "Batteriefluss für Laden ist positiv",
         "battery_charge_only_from_generation": "Batterien werden nur über Solar geladen",
         "battery_hint_std": "Entladeleistung der Batterie (Ein- und Ausgang kombiniert, positiver Wert = Entladen)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Power to grid (optional)",
         "generation_entity": "Power from generation (optional)",
         "hide_small_consumers": "Group consumers below 20W",
+        "hide_zero_consumers": "Hide devices with zero consumption",
         "invert_battery_flows": "Battery flows are positive for charging",
         "battery_charge_only_from_generation": "Batteries can only charge from generated power",
         "battery_hint_std": "Power from battery (one combined in/out per battery, positive = discharging)",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -24,6 +24,7 @@
         "power_to_grid_entity": "Potencia a la red (opcional)",
         "generation_entity": "Potencia de generación (opcional)",
         "hide_small_consumers": "Agrupar consumidores menores de 20W",
+        "hide_zero_consumers": "Ocultar dispositivos sin consumo",
         "invert_battery_flows": "Los flujos de la batería son positivos al cargar",
         "battery_charge_only_from_generation": "Las baterías solo pueden cargarse con energía generada",
         "battery_hint_std": "Potencia desde la batería (una combinación de entrada/salida por batería, positivo = descarga)",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Puissance vers le réseaux (optionnel)",
         "generation_entity": "Puissance depuis les générateur/solaire (optionnel)",
         "hide_small_consumers": "Groupper les consommateurs de moins de 20W",
+        "hide_zero_consumers": "Masquer les appareils sans consommation",
         "invert_battery_flows": "Le flux de batterie sont positifs pour la charge",
         "battery_charge_only_from_generation": "Les batteries ne peuvent se charger qu'à partir de l'énergie générée",
         "battery_hint_std": "Puissance depuis les batteries (une entrée/sortie combinée par batterie, positive = décharge)",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Potenza alla rete (opzionale)",
         "generation_entity": "Potenza da generazione (opzionale)",
         "hide_small_consumers": "Raggruppa personalizzati sotto i 20W",
+        "hide_zero_consumers": "Nascondi dispositivi senza consumo",
         "invert_battery_flows": "Flussi batteria sono positivi quando in carica",
         "battery_charge_only_from_generation": "Batterie possono essere ricaricate solo da generazione",
         "battery_hint_std": "Potenza da batterie (combinato in/out per batteria, positivo = in scarica)",

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "系統への電力 (任意)",
         "generation_entity": "発電からの電力 (任意)",
         "hide_small_consumers": "20W以下の消費をグループ化する",
+        "hide_zero_consumers": "消費がゼロのデバイスを非表示にする",
         "invert_battery_flows": "蓄電器の電力は＋で充電を示します",
         "battery_charge_only_from_generation": "蓄電器は発電からの電力でのみ充電する",
         "battery_hint_std": "蓄電器からの放電(入出力をまとめた値、＋は放電を示します)",

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Vermogen naar het net (optioneel)",
         "generation_entity": "Vermogen vanuit opwekking (optioneel)",
         "hide_small_consumers": "Groepeer verbruikers onder 20W",
+        "hide_zero_consumers": "Verberg apparaten zonder verbruik",
         "invert_battery_flows": "Batterijstroom is positief bij opladen",
         "battery_charge_only_from_generation": "Batterijen alleen opladen vanuit opgewekt vermogen",
         "battery_hint_std": "Vermogen vanuit batterij (in/uit gecombineerd per batterij, positief = ontladen)",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Potência para a rede (opcional)",
         "generation_entity": "Potência da geração (opcional)",
         "hide_small_consumers": "Grupo de consumidores abaixo de 20W",
+        "hide_zero_consumers": "Ocultar dispositivos sem consumo",
         "invert_battery_flows": "Os fluxos da bateria são positivos ao carregar",
         "battery_charge_only_from_generation": "As baterias só podem ser carregadas com energia gerada",
         "battery_hint_std": "Potência da bateria (uma entrada/saída combinada por bateria, positivo = descarregando)",

--- a/src/translations/ro.json
+++ b/src/translations/ro.json
@@ -25,6 +25,7 @@
         "power_to_grid_entity": "Energie catre retea (optional)",
         "generation_entity": "Energie produsa solar/generator (optional)",
         "hide_small_consumers": "Grupeaza consumatorii sub 20W",
+        "hide_zero_consumers": "Ascunde dispozitivele fără consum",
         "invert_battery_flows": "Bateria are valori pozitive la incarcare",
         "battery_charge_only_from_generation": "Bateriile se incarca doar din energie produsa solar/generator",
         "battery_hint_std": "Energie din baterie (combinata in/out pe baterie, pozitiva = descarcare)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface PowerFlowCardConfig extends ElecFlowCardConfig {
   power_to_grid_entity?: string;
   generation_entity?: string;
   independent_grid_in_out?: boolean;
+  hide_zero_consumers?: boolean;
   consumer_entities: {
     entity: string;
     name?: string;


### PR DESCRIPTION
Adds a new boolean option hide_zero_consumers to the Power Flow Card. When enabled, any consumer reporting exactly 0 W is removed from the sankey diagram (filtered out before the existing "group small consumers" logic), which helps declutter diagrams with many zero-value entities; the default is false so behavior is unchanged unless turned on.

Change is scoped to the Power Flow Card (editor toggle + config handling) and the sankey filtering; it's backwards-compatible. To test, enable the new toggle in the power card editor and confirm consumer entities showing 0 W are no longer displayed (they are removed, not grouped into "Other").